### PR TITLE
Improve UBSignal initialization safety

### DIFF
--- a/UberSignals.podspec
+++ b/UberSignals.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'UberSignals'
-  s.version = '1.0.1'
+  s.version = '2.0.0'
   s.license = { :type => 'MIT' }
   s.summary = 'Signals is an eventing framework that enables you to implement the Observable pattern without using NSNotifications.'
   s.homepage = 'https://github.com/uber/signals-ios'

--- a/UberSignals/UBSignal.h
+++ b/UberSignals/UBSignal.h
@@ -120,8 +120,10 @@ typedef void (^UBSignalObserverChange)(UBSignalObserver *signalObserver);
  */
 @property (nonatomic, strong) UBSignalObserverChange observerRemoved;
 
+- (instancetype)init NS_UNAVAILABLE;
+
 /**
- Initializes a Signal with a given protocol.
+ Initializes a Signal with a given protocol. An empty signal should call this initializer with the EmptySignal protocol.
  */
 - (instancetype)initWithProtocol:(Protocol *)protocol NS_DESIGNATED_INITIALIZER;
 

--- a/UberSignals/UBSignal.m
+++ b/UberSignals/UBSignal.m
@@ -56,56 +56,7 @@ typedef void (^UBSignalFire) (id arg1, id arg2, id arg3, id arg4, id arg5);
         _maxObservers = 20;
         
         __weak typeof(self) weakSelf = self;
-        if (protocol) {
-            if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount1))) {
-                _fire = ^void(id arg1) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1)] forSignalObservers:weakSelf.signalObservers];
-                };
-                _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1)] forSignalObservers:@[signalObserver]];
-                };
-            } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount2))) {
-                _fire = ^void(id arg1, id arg2) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2)] forSignalObservers:weakSelf.signalObservers];
-                };
-                _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1, id arg2) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2)] forSignalObservers:@[signalObserver]];
-                };
-            } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount3))) {
-                _fire = ^void(id arg1, id arg2, id arg3) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3)] forSignalObservers:weakSelf.signalObservers];
-                };
-                _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1, id arg2, id arg3) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3)] forSignalObservers:@[signalObserver]];
-                };
-            } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount4))) {
-                _fire = ^void(id arg1, id arg2, id arg3, id arg4) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3), WrapNil(arg4)] forSignalObservers:weakSelf.signalObservers];
-                };
-                _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1, id arg2, id arg3, id arg4) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3), WrapNil(arg4)] forSignalObservers:@[signalObserver]];
-                };
-            } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount5))) {
-                _fire = ^void(id arg1, id arg2, id arg3, id arg4, id arg5) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3), WrapNil(arg4), WrapNil(arg5)] forSignalObservers:weakSelf.signalObservers];
-                };
-                _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1, id arg2, id arg3, id arg4, id arg5) {
-                    __strong typeof(weakSelf) strongSelf = weakSelf;
-                    [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3), WrapNil(arg4), WrapNil(arg5)] forSignalObservers:@[signalObserver]];
-                };
-            } else {
-                NSAssert(false, @"Protocol doesn't provide parameter count");
-            }
-        } else {
+        if (protocol_conformsToProtocol(protocol, @protocol(EmptySignal))) {
             _fire = (UBSignalFire) ^void() {
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 [strongSelf _fireData:nil forSignalObservers:weakSelf.signalObservers];
@@ -114,6 +65,53 @@ typedef void (^UBSignalFire) (id arg1, id arg2, id arg3, id arg4, id arg5);
                 __strong typeof(weakSelf) strongSelf = weakSelf;
                 [strongSelf _fireData:nil forSignalObservers:@[signalObserver]];
             };
+        } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount1))) {
+            _fire = ^void(id arg1) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1)] forSignalObservers:weakSelf.signalObservers];
+            };
+            _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1)] forSignalObservers:@[signalObserver]];
+            };
+        } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount2))) {
+            _fire = ^void(id arg1, id arg2) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2)] forSignalObservers:weakSelf.signalObservers];
+            };
+            _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1, id arg2) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2)] forSignalObservers:@[signalObserver]];
+            };
+        } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount3))) {
+            _fire = ^void(id arg1, id arg2, id arg3) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3)] forSignalObservers:weakSelf.signalObservers];
+            };
+            _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1, id arg2, id arg3) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3)] forSignalObservers:@[signalObserver]];
+            };
+        } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount4))) {
+            _fire = ^void(id arg1, id arg2, id arg3, id arg4) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3), WrapNil(arg4)] forSignalObservers:weakSelf.signalObservers];
+            };
+            _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1, id arg2, id arg3, id arg4) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3), WrapNil(arg4)] forSignalObservers:@[signalObserver]];
+            };
+        } else if (protocol_conformsToProtocol(protocol, @protocol(UBSignalArgumentCount5))) {
+            _fire = ^void(id arg1, id arg2, id arg3, id arg4, id arg5) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3), WrapNil(arg4), WrapNil(arg5)] forSignalObservers:weakSelf.signalObservers];
+            };
+            _fireForSignalObserver = ^void(UBSignalObserver *signalObserver, id arg1, id arg2, id arg3, id arg4, id arg5) {
+                __strong typeof(weakSelf) strongSelf = weakSelf;
+                [strongSelf _fireNewData:@[WrapNil(arg1), WrapNil(arg2), WrapNil(arg3), WrapNil(arg4), WrapNil(arg5)] forSignalObservers:@[signalObserver]];
+            };
+        } else {
+            NSAssert(false, @"Protocol doesn't provide parameter count");
         }
     }
     return self;
@@ -121,9 +119,9 @@ typedef void (^UBSignalFire) (id arg1, id arg2, id arg3, id arg4, id arg5);
 
 - (instancetype)init
 {
-    return [self initWithProtocol:nil];
+    [NSException raise:@"Incorrect initializer" format:@"%@ is unavailable, use %@.", NSStringFromSelector(_cmd), NSStringFromSelector(@selector(initWithProtocol:))];
+    return nil;
 }
-
 
 #pragma mark - NSObject
 

--- a/UberSignalsTests/UBSignalEmitter.m
+++ b/UberSignalsTests/UBSignalEmitter.m
@@ -30,7 +30,7 @@
 {
     self = [super init];
     if (self) {
-        _onEmptySignal = (UBSignal<EmptySignal> *)[[UBSignal alloc] init];
+        _onEmptySignal = (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
         _onIntegerSignal = (UBSignal<IntegerSignal> *)[[UBSignal alloc] initWithProtocol:@protocol(IntegerSignal)];
         _onStringSignal = (UBSignal<TupleSignal> *)[[UBSignal alloc] initWithProtocol:@protocol(TupleSignal)];
         _onTripleSignal = (UBSignal<TripleSignal> *)[[UBSignal alloc] initWithProtocol:@protocol(TripleSignal)];

--- a/UberSignalsTests/UBSignalTests.m
+++ b/UberSignalsTests/UBSignalTests.m
@@ -595,7 +595,7 @@
 
 - (void)testMaxObservers
 {
-    UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] init];
+    UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
     signal.maxObservers = 2;
     
     [signal addObserver:self callback:^(id self) {}];
@@ -606,7 +606,7 @@
 
 - (void)testSettingMaxObserversBelowObservers
 {
-    UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] init];
+    UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
     [signal addObserver:self callback:^(id self) {}];
     [signal addObserver:self callback:^(id self) {}];
     
@@ -616,7 +616,7 @@
 
 - (void)testAllArgumentCounts
 {
-    UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] init];
+    UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
     signal.maxObservers = 2;
     
     [signal addObserver:self callback:^(id self) {}];
@@ -627,7 +627,7 @@
 
 - (void)testObservingWithoutCallback
 {
-    UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] init];
+    UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
     XCTAssertThrows([signal addObserver:nil callback:^(id self) {}], @"Should have complained about nil observer");
     XCTAssertThrows([signal addObserver:self callback:nil], @"Should have complained about nil callback");
 }


### PR DESCRIPTION
UBSignal can be initialized with `init` however this is not always what someone wants to do, so to make this a little more explicit and safe, I'm marking `init` as unavailable, raising a runtime exception, and improving the headerdoc to denote that if you want an empty signal then you should pass in the `EmptySignal` protocol explicitly.

Also bumping the major to 2.0 as this is a breaking change.
