### PR TITLE
Adds a class level helper method for creating empty signals

### DIFF
--- a/UberSignals/UBSignal.h
+++ b/UberSignals/UBSignal.h
@@ -37,8 +37,6 @@
 #define CreateSignalType(name, signature...)\
     CreateSignalType_(PP_NARG(signature),name,signature)
 
-#define InitializeSignalProtocol(protocol)\
-   (UBSignal<protocol> *)[[UBSignal alloc] initWithProtocol:@protocol(protocol)];
 /**
  A special type of signal that doesn't have any parameters.
  */

--- a/UberSignals/UBSignal.h
+++ b/UberSignals/UBSignal.h
@@ -120,6 +120,11 @@ typedef void (^UBSignalObserverChange)(UBSignalObserver *signalObserver);
  */
 @property (nonatomic, strong) UBSignalObserverChange observerRemoved;
 
+/**
+ Helper constructor, Initializes an empty signal with the EmptySignal protocol.
+ */
++ (UBSignal<EmptySignal> *)emptySignal;
+
 - (instancetype)init NS_UNAVAILABLE;
 
 /**

--- a/UberSignals/UBSignal.h
+++ b/UberSignals/UBSignal.h
@@ -37,6 +37,8 @@
 #define CreateSignalType(name, signature...)\
     CreateSignalType_(PP_NARG(signature),name,signature)
 
+#define InitializeSignalProtocol(protocol)\
+   (UBSignal<protocol> *)[[UBSignal alloc] initWithProtocol:@protocol(protocol)];
 /**
  A special type of signal that doesn't have any parameters.
  */
@@ -121,7 +123,7 @@ typedef void (^UBSignalObserverChange)(UBSignalObserver *signalObserver);
 @property (nonatomic, strong) UBSignalObserverChange observerRemoved;
 
 /**
- Helper constructor, Initializes an empty signal with the EmptySignal protocol.
+ Helper factory method, constructs a Signal instance with the EmptySignal protocol.
  */
 + (UBSignal<EmptySignal> *)emptySignal;
 

--- a/UberSignals/UBSignal.m
+++ b/UberSignals/UBSignal.m
@@ -46,6 +46,11 @@ typedef void (^UBSignalFire) (id arg1, id arg2, id arg3, id arg4, id arg5);
 
 @implementation UBSignal
 
++ (UBSignal<EmptySignal> *)emptySignal
+{
+    return (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
+}
+
 #pragma mark - Initializers
 
 - (instancetype)initWithProtocol:(Protocol *)protocol

--- a/UberSignals/UBSignal.m
+++ b/UberSignals/UBSignal.m
@@ -48,7 +48,7 @@ typedef void (^UBSignalFire) (id arg1, id arg2, id arg3, id arg4, id arg5);
 
 + (UBSignal<EmptySignal> *)emptySignal
 {
-    return (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
+    return InitializeSignalProtocol(EmptySignal);
 }
 
 #pragma mark - Initializers

--- a/UberSignals/UBSignal.m
+++ b/UberSignals/UBSignal.m
@@ -48,7 +48,7 @@ typedef void (^UBSignalFire) (id arg1, id arg2, id arg3, id arg4, id arg5);
 
 + (UBSignal<EmptySignal> *)emptySignal
 {
-    return InitializeSignalProtocol(EmptySignal);
+    return (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
 }
 
 #pragma mark - Initializers

--- a/UberSignalsTests/UBSignalTests.m
+++ b/UberSignalsTests/UBSignalTests.m
@@ -717,4 +717,10 @@
     XCTAssertNil(weakObserver, @"Should have deallocated observer");
 }
 
+- (void)testUBSignalHelper
+{
+    UBSignal<EmptySignal> *emptySignalWithHelper = [UBSignal emptySignal];
+    XCTAssertEqualObjects([emptySignalWithHelper class], [UBSignal class]);
+}
+
 @end

--- a/UberSignalsTests/UBSignalTests.m
+++ b/UberSignalsTests/UBSignalTests.m
@@ -720,7 +720,7 @@
 - (void)testUBSignalHelper
 {
     UBSignal<EmptySignal> *emptySignalWithHelper = [UBSignal emptySignal];
-    XCTAssertEqualObjects([emptySignalWithHelper class], [UBSignal class]);
+    XCTAssertEqualObjects([emptySignalWithHelper class], [UBSignal class], @"Object created with helper factory method should be a UBSignal");
 }
 
 @end


### PR DESCRIPTION
Not sure if we want this. Just threw something up since I found myself writing a lot of this boilerplate. This is also the only 'special' signal protocol that comes in the framework, and perhaps warrants its own common case constructor.
