### PR TITLE
Make Signals available for Mac OS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: objective-c
-xcode_project: UberSignals.xcodeproj
-xcode_scheme: UberSignals
+xcode_project: "UberSignals.xcodeproj"
+xcode_scheme: "UberSignals iOS"
 osx_image: xcode6.4
 xcode_sdk: iphonesimulator8.4
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,18 @@
 language: objective-c
-xcode_project: "UberSignals.xcodeproj"
-xcode_scheme: "UberSignals iOS"
-osx_image: xcode6.4
-xcode_sdk: iphonesimulator8.4
+osx_image: xcode7.1
+env:
+  global:
+  - LC_CTYPE=en_US.UTF-8
+  - LANG=en_US.UTF-8
+  matrix:
+    - DESTINATION="OS=9.1,name=iPhone 6s" SCHEME="UberSignals iOS" SDK=iphonesimulator9.1
+    - DESTINATION="platform=OS X,arch=x86_64" SCHEME="UberSignals OSX" SDK=macosx10.11
+script:
+  - set -o pipefail
+  - xcodebuild -version
+  - xcodebuild -showsdks
+  - instruments -s devices
+  - xcodebuild -project UberSignals.xcodeproj -scheme "$SCHEME" -destination "$DESTINATION" -sdk="SDK" -configuration Release ONLY_ACTIVE_ARCH=NO clean build | xcpretty -c;
+  - xcodebuild -project UberSignals.xcodeproj -scheme "$SCHEME" -destination "$DESTINATION" -sdk="SDK" -configuration Debug ONLY_ACTIVE_ARCH=NO clean build test | xcpretty -c;
 notifications:
   email: false

--- a/UberSignals.podspec
+++ b/UberSignals.podspec
@@ -9,10 +9,13 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/uber/signals-ios.git', :tag => s.version }
   s.requires_arc = true
 
-  s.ios.deployment_target = '7.0'
+  s.ios.deployment_target = '8.0'
+  s.osx.deployment_target = '10.7'
 
   s.source_files = "#{s.name}/**/*.{h,m}"
   s.private_header_files = "#{s.name}/**/*+Internal.h"
 
-  s.frameworks  = "Foundation"
+  s.ios.frameworks = 'Foundation'
+  s.osx.frameworks = 'Foundation'
+
 end

--- a/UberSignals.xcodeproj/project.pbxproj
+++ b/UberSignals.xcodeproj/project.pbxproj
@@ -26,6 +26,9 @@
 		72FED2311B2C97D800DCAB7E /* UBSignalObserver+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED2291B2C97D800DCAB7E /* UBSignalObserver+Internal.h */; };
 		72FED2331B2C97E500DCAB7E /* UBSignalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2321B2C97E500DCAB7E /* UBSignalTests.m */; };
 		72FED2361B2C97EB00DCAB7E /* UBSignalEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2351B2C97EB00DCAB7E /* UBSignalEmitter.m */; };
+		B643B4741C1EE50D00BE2A3B /* UBSignalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2321B2C97E500DCAB7E /* UBSignalTests.m */; };
+		B643B4751C1EE50D00BE2A3B /* UBSignalEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2351B2C97EB00DCAB7E /* UBSignalEmitter.m */; };
+		B643B4771C1EE50D00BE2A3B /* UberSignals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72FED2061B2C97C400DCAB7E /* UberSignals.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -35,6 +38,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 72FED2051B2C97C400DCAB7E;
 			remoteInfo = UberSignals;
+		};
+		B68E5C6E1C1F1EDF00D80117 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 72FED1FD1B2C97C400DCAB7E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 5EBEBDAE1C162DE000E8CA02;
+			remoteInfo = "UberSignals OSX";
 		};
 /* End PBXContainerItemProxy section */
 
@@ -56,6 +66,7 @@
 		72FED2321B2C97E500DCAB7E /* UBSignalTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSignalTests.m; sourceTree = "<group>"; };
 		72FED2341B2C97EB00DCAB7E /* UBSignalEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSignalEmitter.h; sourceTree = "<group>"; };
 		72FED2351B2C97EB00DCAB7E /* UBSignalEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSignalEmitter.m; sourceTree = "<group>"; };
+		B643B47C1C1EE50D00BE2A3B /* UberSignals OSX Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UberSignals OSX Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -81,6 +92,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B643B4761C1EE50D00BE2A3B /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B643B4771C1EE50D00BE2A3B /* UberSignals.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
@@ -100,6 +119,7 @@
 				72FED2061B2C97C400DCAB7E /* UberSignals.framework */,
 				72FED2111B2C97C400DCAB7E /* UberSignalsTests.xctest */,
 				5EBEBDAF1C162DE000E8CA02 /* UberSignals.framework */,
+				B643B47C1C1EE50D00BE2A3B /* UberSignals OSX Tests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -241,13 +261,31 @@
 			productReference = 72FED2111B2C97C400DCAB7E /* UberSignalsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		B643B4701C1EE50D00BE2A3B /* UberSignals OSX Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B643B4791C1EE50D00BE2A3B /* Build configuration list for PBXNativeTarget "UberSignals OSX Tests" */;
+			buildPhases = (
+				B643B4731C1EE50D00BE2A3B /* Sources */,
+				B643B4761C1EE50D00BE2A3B /* Frameworks */,
+				B643B4781C1EE50D00BE2A3B /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B68E5C6F1C1F1EDF00D80117 /* PBXTargetDependency */,
+			);
+			name = "UberSignals OSX Tests";
+			productName = UberSignalsTests;
+			productReference = B643B47C1C1EE50D00BE2A3B /* UberSignals OSX Tests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
 		72FED1FD1B2C97C400DCAB7E /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0720;
 				ORGANIZATIONNAME = "Uber Technologies Inc.";
 				TargetAttributes = {
 					5EBEBDAE1C162DE000E8CA02 = {
@@ -276,6 +314,7 @@
 				72FED2051B2C97C400DCAB7E /* UberSignals iOS */,
 				72FED2101B2C97C400DCAB7E /* UberSignals iOS Tests */,
 				5EBEBDAE1C162DE000E8CA02 /* UberSignals OSX */,
+				B643B4701C1EE50D00BE2A3B /* UberSignals OSX Tests */,
 			);
 		};
 /* End PBXProject section */
@@ -296,6 +335,13 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		72FED20F1B2C97C400DCAB7E /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B643B4781C1EE50D00BE2A3B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -332,6 +378,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B643B4731C1EE50D00BE2A3B /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B643B4741C1EE50D00BE2A3B /* UBSignalTests.m in Sources */,
+				B643B4751C1EE50D00BE2A3B /* UBSignalEmitter.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -339,6 +394,11 @@
 			isa = PBXTargetDependency;
 			target = 72FED2051B2C97C400DCAB7E /* UberSignals iOS */;
 			targetProxy = 72FED2131B2C97C400DCAB7E /* PBXContainerItemProxy */;
+		};
+		B68E5C6F1C1F1EDF00D80117 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 5EBEBDAE1C162DE000E8CA02 /* UberSignals OSX */;
+			targetProxy = B68E5C6E1C1F1EDF00D80117 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -488,6 +548,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UberSignals;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -505,6 +566,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UberSignals;
+				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -520,6 +582,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ubercab.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UberSignalsTests;
+				SDKROOT = iphoneos;
 			};
 			name = Debug;
 		};
@@ -530,6 +593,37 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ubercab.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = UberSignalsTests;
+				SDKROOT = iphoneos;
+			};
+			name = Release;
+		};
+		B643B47A1C1EE50D00BE2A3B /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = UberSignalsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ubercab.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
+			};
+			name = Debug;
+		};
+		B643B47B1C1EE50D00BE2A3B /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				COMBINE_HIDPI_IMAGES = YES;
+				INFOPLIST_FILE = UberSignalsTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.ubercab.$(PRODUCT_NAME:rfc1034identifier)";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = macosx;
 			};
 			name = Release;
 		};
@@ -543,6 +637,7 @@
 				5EBEBDB51C162DE100E8CA02 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		72FED2001B2C97C400DCAB7E /* Build configuration list for PBXProject "UberSignals" */ = {
 			isa = XCConfigurationList;
@@ -567,6 +662,15 @@
 			buildConfigurations = (
 				72FED2201B2C97C400DCAB7E /* Debug */,
 				72FED2211B2C97C400DCAB7E /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		B643B4791C1EE50D00BE2A3B /* Build configuration list for PBXNativeTarget "UberSignals OSX Tests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B643B47A1C1EE50D00BE2A3B /* Debug */,
+				B643B47B1C1EE50D00BE2A3B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/UberSignals.xcodeproj/project.pbxproj
+++ b/UberSignals.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		5EBEBDB71C162E6600E8CA02 /* UBSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED2231B2C97D800DCAB7E /* UBSignal.h */; };
+		5EBEBDB81C162E6600E8CA02 /* UBSignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2241B2C97D800DCAB7E /* UBSignal.m */; };
+		5EBEBDB91C162E6600E8CA02 /* UBSignal+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED2251B2C97D800DCAB7E /* UBSignal+Internal.h */; };
+		5EBEBDBA1C162E6600E8CA02 /* UBSignal+Preprocessor.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED2261B2C97D800DCAB7E /* UBSignal+Preprocessor.h */; };
+		5EBEBDBB1C162E6600E8CA02 /* UBSignalObserver.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED2271B2C97D800DCAB7E /* UBSignalObserver.h */; };
+		5EBEBDBC1C162E6600E8CA02 /* UBSignalObserver.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2281B2C97D800DCAB7E /* UBSignalObserver.m */; };
+		5EBEBDBD1C162E6600E8CA02 /* UBSignalObserver+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED2291B2C97D800DCAB7E /* UBSignalObserver+Internal.h */; };
+		5EBEBDBE1C162E6600E8CA02 /* UberSignals.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED20B1B2C97C400DCAB7E /* UberSignals.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		72FED20C1B2C97C400DCAB7E /* UberSignals.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED20B1B2C97C400DCAB7E /* UberSignals.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		72FED2121B2C97C400DCAB7E /* UberSignals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72FED2061B2C97C400DCAB7E /* UberSignals.framework */; };
 		72FED22B1B2C97D800DCAB7E /* UBSignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED2231B2C97D800DCAB7E /* UBSignal.h */; };
@@ -31,6 +39,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		5EBEBDAF1C162DE000E8CA02 /* UberSignals.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UberSignals.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72F45D921B8C0F910025F83C /* UberSignals.podspec */ = {isa = PBXFileReference; lastKnownFileType = text; path = UberSignals.podspec; sourceTree = "<group>"; };
 		72FED2061B2C97C400DCAB7E /* UberSignals.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = UberSignals.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		72FED20A1B2C97C400DCAB7E /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
@@ -50,6 +59,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		5EBEBDAB1C162DE000E8CA02 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72FED2021B2C97C400DCAB7E /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -83,6 +99,7 @@
 			children = (
 				72FED2061B2C97C400DCAB7E /* UberSignals.framework */,
 				72FED2111B2C97C400DCAB7E /* UberSignalsTests.xctest */,
+				5EBEBDAF1C162DE000E8CA02 /* UberSignals.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -141,6 +158,19 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		5EBEBDAC1C162DE000E8CA02 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5EBEBDBE1C162E6600E8CA02 /* UberSignals.h in Headers */,
+				5EBEBDBD1C162E6600E8CA02 /* UBSignalObserver+Internal.h in Headers */,
+				5EBEBDBA1C162E6600E8CA02 /* UBSignal+Preprocessor.h in Headers */,
+				5EBEBDBB1C162E6600E8CA02 /* UBSignalObserver.h in Headers */,
+				5EBEBDB91C162E6600E8CA02 /* UBSignal+Internal.h in Headers */,
+				5EBEBDB71C162E6600E8CA02 /* UBSignal.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72FED2031B2C97C400DCAB7E /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -157,9 +187,27 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		72FED2051B2C97C400DCAB7E /* UberSignals */ = {
+		5EBEBDAE1C162DE000E8CA02 /* UberSignals OSX */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 72FED21C1B2C97C400DCAB7E /* Build configuration list for PBXNativeTarget "UberSignals" */;
+			buildConfigurationList = 5EBEBDB61C162DE100E8CA02 /* Build configuration list for PBXNativeTarget "UberSignals OSX" */;
+			buildPhases = (
+				5EBEBDAA1C162DE000E8CA02 /* Sources */,
+				5EBEBDAB1C162DE000E8CA02 /* Frameworks */,
+				5EBEBDAC1C162DE000E8CA02 /* Headers */,
+				5EBEBDAD1C162DE000E8CA02 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "UberSignals OSX";
+			productName = "UberSignals OSX";
+			productReference = 5EBEBDAF1C162DE000E8CA02 /* UberSignals.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		72FED2051B2C97C400DCAB7E /* UberSignals iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 72FED21C1B2C97C400DCAB7E /* Build configuration list for PBXNativeTarget "UberSignals iOS" */;
 			buildPhases = (
 				72FED2011B2C97C400DCAB7E /* Sources */,
 				72FED2021B2C97C400DCAB7E /* Frameworks */,
@@ -170,14 +218,14 @@
 			);
 			dependencies = (
 			);
-			name = UberSignals;
+			name = "UberSignals iOS";
 			productName = UberSignals;
 			productReference = 72FED2061B2C97C400DCAB7E /* UberSignals.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		72FED2101B2C97C400DCAB7E /* UberSignalsTests */ = {
+		72FED2101B2C97C400DCAB7E /* UberSignals iOS Tests */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 72FED21F1B2C97C400DCAB7E /* Build configuration list for PBXNativeTarget "UberSignalsTests" */;
+			buildConfigurationList = 72FED21F1B2C97C400DCAB7E /* Build configuration list for PBXNativeTarget "UberSignals iOS Tests" */;
 			buildPhases = (
 				72FED20D1B2C97C400DCAB7E /* Sources */,
 				72FED20E1B2C97C400DCAB7E /* Frameworks */,
@@ -188,7 +236,7 @@
 			dependencies = (
 				72FED2141B2C97C400DCAB7E /* PBXTargetDependency */,
 			);
-			name = UberSignalsTests;
+			name = "UberSignals iOS Tests";
 			productName = UberSignalsTests;
 			productReference = 72FED2111B2C97C400DCAB7E /* UberSignalsTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
@@ -202,6 +250,9 @@
 				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Uber Technologies Inc.";
 				TargetAttributes = {
+					5EBEBDAE1C162DE000E8CA02 = {
+						CreatedOnToolsVersion = 7.1.1;
+					};
 					72FED2051B2C97C400DCAB7E = {
 						CreatedOnToolsVersion = 6.3.2;
 					};
@@ -222,13 +273,21 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				72FED2051B2C97C400DCAB7E /* UberSignals */,
-				72FED2101B2C97C400DCAB7E /* UberSignalsTests */,
+				72FED2051B2C97C400DCAB7E /* UberSignals iOS */,
+				72FED2101B2C97C400DCAB7E /* UberSignals iOS Tests */,
+				5EBEBDAE1C162DE000E8CA02 /* UberSignals OSX */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		5EBEBDAD1C162DE000E8CA02 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72FED2041B2C97C400DCAB7E /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -246,6 +305,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		5EBEBDAA1C162DE000E8CA02 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5EBEBDBC1C162E6600E8CA02 /* UBSignalObserver.m in Sources */,
+				5EBEBDB81C162E6600E8CA02 /* UBSignal.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		72FED2011B2C97C400DCAB7E /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -269,12 +337,55 @@
 /* Begin PBXTargetDependency section */
 		72FED2141B2C97C400DCAB7E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			target = 72FED2051B2C97C400DCAB7E /* UberSignals */;
+			target = 72FED2051B2C97C400DCAB7E /* UberSignals iOS */;
 			targetProxy = 72FED2131B2C97C400DCAB7E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		5EBEBDB41C162DE100E8CA02 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = UberSignals/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.UberSignals.UberSignals-OSX";
+				PRODUCT_NAME = UberSignals;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Debug;
+		};
+		5EBEBDB51C162DE100E8CA02 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "-";
+				COMBINE_HIDPI_IMAGES = YES;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				FRAMEWORK_VERSION = A;
+				INFOPLIST_FILE = UberSignals/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/Frameworks";
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
+				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.UberSignals.UberSignals-OSX";
+				PRODUCT_NAME = UberSignals;
+				SDKROOT = macosx;
+				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
 		72FED21A1B2C97C400DCAB7E /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -376,7 +487,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = UberSignals;
 				SKIP_INSTALL = YES;
 			};
 			name = Debug;
@@ -393,7 +504,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.uber.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = UberSignals;
 				SKIP_INSTALL = YES;
 			};
 			name = Release;
@@ -408,7 +519,7 @@
 				INFOPLIST_FILE = UberSignalsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ubercab.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = UberSignalsTests;
 			};
 			name = Debug;
 		};
@@ -418,13 +529,21 @@
 				INFOPLIST_FILE = UberSignalsTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.ubercab.$(PRODUCT_NAME:rfc1034identifier)";
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_NAME = UberSignalsTests;
 			};
 			name = Release;
 		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		5EBEBDB61C162DE100E8CA02 /* Build configuration list for PBXNativeTarget "UberSignals OSX" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				5EBEBDB41C162DE100E8CA02 /* Debug */,
+				5EBEBDB51C162DE100E8CA02 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		72FED2001B2C97C400DCAB7E /* Build configuration list for PBXProject "UberSignals" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -434,7 +553,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		72FED21C1B2C97C400DCAB7E /* Build configuration list for PBXNativeTarget "UberSignals" */ = {
+		72FED21C1B2C97C400DCAB7E /* Build configuration list for PBXNativeTarget "UberSignals iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				72FED21D1B2C97C400DCAB7E /* Debug */,
@@ -443,7 +562,7 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		72FED21F1B2C97C400DCAB7E /* Build configuration list for PBXNativeTarget "UberSignalsTests" */ = {
+		72FED21F1B2C97C400DCAB7E /* Build configuration list for PBXNativeTarget "UberSignals iOS Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				72FED2201B2C97C400DCAB7E /* Debug */,

--- a/UberSignals.xcodeproj/xcshareddata/xcschemes/UberSignals OSX.xcscheme
+++ b/UberSignals.xcodeproj/xcshareddata/xcschemes/UberSignals OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0710"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "5EBEBDAE1C162DE000E8CA02"
-               BuildableName = "UberSignals OSX.framework"
+               BuildableName = "UberSignals.framework"
                BlueprintName = "UberSignals OSX"
                ReferencedContainer = "container:UberSignals.xcodeproj">
             </BuildableReference>
@@ -28,7 +28,26 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B643B4701C1EE50D00BE2A3B"
+               BuildableName = "UberSignals OSX Tests.xctest"
+               BlueprintName = "UberSignals OSX Tests"
+               ReferencedContainer = "container:UberSignals.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "5EBEBDAE1C162DE000E8CA02"
+            BuildableName = "UberSignals.framework"
+            BlueprintName = "UberSignals OSX"
+            ReferencedContainer = "container:UberSignals.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <AdditionalOptions>
       </AdditionalOptions>
    </TestAction>
@@ -46,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5EBEBDAE1C162DE000E8CA02"
-            BuildableName = "UberSignals OSX.framework"
+            BuildableName = "UberSignals.framework"
             BlueprintName = "UberSignals OSX"
             ReferencedContainer = "container:UberSignals.xcodeproj">
          </BuildableReference>
@@ -64,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "5EBEBDAE1C162DE000E8CA02"
-            BuildableName = "UberSignals OSX.framework"
+            BuildableName = "UberSignals.framework"
             BlueprintName = "UberSignals OSX"
             ReferencedContainer = "container:UberSignals.xcodeproj">
          </BuildableReference>

--- a/UberSignals.xcodeproj/xcshareddata/xcschemes/UberSignals OSX.xcscheme
+++ b/UberSignals.xcodeproj/xcshareddata/xcschemes/UberSignals OSX.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0710"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -14,70 +14,40 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "72FED2051B2C97C400DCAB7E"
-               BuildableName = "UberSignals.framework"
-               BlueprintName = "UberSignals"
-               ReferencedContainer = "container:UberSignals.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "NO"
-            buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "72FED2101B2C97C400DCAB7E"
-               BuildableName = "UberSignalsTests.xctest"
-               BlueprintName = "UberSignalsTests"
+               BlueprintIdentifier = "5EBEBDAE1C162DE000E8CA02"
+               BuildableName = "UberSignals OSX.framework"
+               BlueprintName = "UberSignals OSX"
                ReferencedContainer = "container:UberSignals.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES"
-      buildConfiguration = "Debug">
+      shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
-         <TestableReference
-            skipped = "NO">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "72FED2101B2C97C400DCAB7E"
-               BuildableName = "UberSignalsTests.xctest"
-               BlueprintName = "UberSignalsTests"
-               ReferencedContainer = "container:UberSignals.xcodeproj">
-            </BuildableReference>
-         </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "72FED2051B2C97C400DCAB7E"
-            BuildableName = "UberSignals.framework"
-            BlueprintName = "UberSignals"
-            ReferencedContainer = "container:UberSignals.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
+      buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "72FED2051B2C97C400DCAB7E"
-            BuildableName = "UberSignals.framework"
-            BlueprintName = "UberSignals"
+            BlueprintIdentifier = "5EBEBDAE1C162DE000E8CA02"
+            BuildableName = "UberSignals OSX.framework"
+            BlueprintName = "UberSignals OSX"
             ReferencedContainer = "container:UberSignals.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
@@ -85,17 +55,17 @@
       </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
+      buildConfiguration = "Release"
       shouldUseLaunchSchemeArgsEnv = "YES"
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
-      buildConfiguration = "Release"
       debugDocumentVersioning = "YES">
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "72FED2051B2C97C400DCAB7E"
-            BuildableName = "UberSignals.framework"
-            BlueprintName = "UberSignals"
+            BlueprintIdentifier = "5EBEBDAE1C162DE000E8CA02"
+            BuildableName = "UberSignals OSX.framework"
+            BlueprintName = "UberSignals OSX"
             ReferencedContainer = "container:UberSignals.xcodeproj">
          </BuildableReference>
       </MacroExpansion>

--- a/UberSignals.xcodeproj/xcshareddata/xcschemes/UberSignals iOS.xcscheme
+++ b/UberSignals.xcodeproj/xcshareddata/xcschemes/UberSignals iOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0640"
+   LastUpgradeVersion = "0720"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/UberSignals.xcodeproj/xcshareddata/xcschemes/UberSignals iOS.xcscheme
+++ b/UberSignals.xcodeproj/xcshareddata/xcschemes/UberSignals iOS.xcscheme
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0640"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "72FED2051B2C97C400DCAB7E"
+               BuildableName = "UberSignals.framework"
+               BlueprintName = "UberSignals iOS"
+               ReferencedContainer = "container:UberSignals.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "72FED2101B2C97C400DCAB7E"
+               BuildableName = "UberSignalsTests.xctest"
+               BlueprintName = "UberSignals iOS Tests"
+               ReferencedContainer = "container:UberSignals.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "72FED2101B2C97C400DCAB7E"
+               BuildableName = "UberSignalsTests.xctest"
+               BlueprintName = "UberSignals iOS Tests"
+               ReferencedContainer = "container:UberSignals.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "72FED2051B2C97C400DCAB7E"
+            BuildableName = "UberSignals.framework"
+            BlueprintName = "UberSignals iOS"
+            ReferencedContainer = "container:UberSignals.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "72FED2051B2C97C400DCAB7E"
+            BuildableName = "UberSignals.framework"
+            BlueprintName = "UberSignals iOS"
+            ReferencedContainer = "container:UberSignals.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "72FED2051B2C97C400DCAB7E"
+            BuildableName = "UberSignals.framework"
+            BlueprintName = "UberSignals iOS"
+            ReferencedContainer = "container:UberSignals.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/UberSignals/UberSignals.h
+++ b/UberSignals/UberSignals.h
@@ -22,8 +22,6 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#import <UIKit/UIKit.h>
-
 //! Project version number for UberSignals.
 FOUNDATION_EXPORT double UberSignalsVersionNumber;
 


### PR DESCRIPTION
It would be nice to make Signals available for Mac OS. Changes:
- Added the Mac OS framework target & shared scheme;
- Renamed schemes & targets to `UberSignals iOS` and `UberSignals OSX`;
- Updated the `.travis.yml` and `UberSignals.podspec` accordingly.
