### PR TITLE
Set podspec iOS target back to 7.0

### DIFF
--- a/UberSignals.podspec
+++ b/UberSignals.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = 'UberSignals'
-  s.version = '2.2.0'
+  s.version = '2.2.1'
   s.license = { :type => 'MIT' }
   s.summary = 'Signals is an eventing framework that enables you to implement the Observable pattern without using NSNotifications.'
   s.homepage = 'https://github.com/uber/signals-ios'

--- a/UberSignals.podspec
+++ b/UberSignals.podspec
@@ -9,7 +9,7 @@ Pod::Spec.new do |s|
   s.source = { :git => 'https://github.com/uber/signals-ios.git', :tag => s.version }
   s.requires_arc = true
 
-  s.ios.deployment_target = '8.0'
+  s.ios.deployment_target = '7.0'
   s.osx.deployment_target = '10.7'
 
   s.source_files = "#{s.name}/**/*.{h,m}"


### PR DESCRIPTION
Signals can still be used to target iOS 7.0. Reverting bump of podspec iOS target.
