### PR TITLE
import Foundation before using FOUNDATION_EXPORT

### DIFF
--- a/UberSignals/UberSignals.h
+++ b/UberSignals/UberSignals.h
@@ -22,6 +22,8 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+#import <Foundation/Foundation.h>
+
 //! Project version number for UberSignals.
 FOUNDATION_EXPORT double UberSignalsVersionNumber;
 


### PR DESCRIPTION
Make sure `Foundation` is imported before using its types. This fails builds without Xcodes magic importing behaviour.
