### PR TITLE
Creates an accompanying convenience initializer method when creating a signal with `CreateSignalType`

### DIFF
--- a/UberSignals.xcodeproj/project.pbxproj
+++ b/UberSignals.xcodeproj/project.pbxproj
@@ -50,6 +50,23 @@
 		72FED2311B2C97D800DCAB7E /* UBSignalObserver+Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 72FED2291B2C97D800DCAB7E /* UBSignalObserver+Internal.h */; };
 		72FED2331B2C97E500DCAB7E /* UBSignalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2321B2C97E500DCAB7E /* UBSignalTests.m */; };
 		72FED2361B2C97EB00DCAB7E /* UBSignalEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2351B2C97EB00DCAB7E /* UBSignalEmitter.m */; };
+		775AAFB01DF2003600EF6CB6 /* UBSignaling.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFAF1DF1FFDA00EF6CB6 /* UBSignaling.h */; };
+		775AAFB11DF2003C00EF6CB6 /* UBSignaling.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFAF1DF1FFDA00EF6CB6 /* UBSignaling.h */; };
+		775AAFB21DF2004200EF6CB6 /* UBSignaling.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFAF1DF1FFDA00EF6CB6 /* UBSignaling.h */; };
+		775AAFB31DF2004700EF6CB6 /* UBSignaling.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFAF1DF1FFDA00EF6CB6 /* UBSignaling.h */; };
+		775AAFB61DF2009900EF6CB6 /* UBEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFB41DF2009900EF6CB6 /* UBEmptySignal.h */; };
+		775AAFB71DF2009900EF6CB6 /* UBEmptySignal.m in Sources */ = {isa = PBXBuildFile; fileRef = 775AAFB51DF2009900EF6CB6 /* UBEmptySignal.m */; };
+		775AAFB81DF2010A00EF6CB6 /* UBEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFB41DF2009900EF6CB6 /* UBEmptySignal.h */; };
+		775AAFB91DF2010F00EF6CB6 /* UBEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFB41DF2009900EF6CB6 /* UBEmptySignal.h */; };
+		775AAFBA1DF2011300EF6CB6 /* UBEmptySignal.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFB41DF2009900EF6CB6 /* UBEmptySignal.h */; };
+		775AAFBD1DF202B600EF6CB6 /* UBSignal+Factory.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFBB1DF202B600EF6CB6 /* UBSignal+Factory.h */; };
+		775AAFBE1DF202B600EF6CB6 /* UBSignal+Factory.m in Sources */ = {isa = PBXBuildFile; fileRef = 775AAFBC1DF202B600EF6CB6 /* UBSignal+Factory.m */; };
+		775AAFBF1DF2031E00EF6CB6 /* UBSignal+Factory.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFBB1DF202B600EF6CB6 /* UBSignal+Factory.h */; };
+		775AAFC01DF2032C00EF6CB6 /* UBSignal+Factory.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFBB1DF202B600EF6CB6 /* UBSignal+Factory.h */; };
+		775AAFC11DF2033100EF6CB6 /* UBSignal+Factory.h in Headers */ = {isa = PBXBuildFile; fileRef = 775AAFBB1DF202B600EF6CB6 /* UBSignal+Factory.h */; };
+		775AAFC21DF203F900EF6CB6 /* UBSignal+Factory.m in Sources */ = {isa = PBXBuildFile; fileRef = 775AAFBC1DF202B600EF6CB6 /* UBSignal+Factory.m */; };
+		775AAFC31DF2040100EF6CB6 /* UBSignal+Factory.m in Sources */ = {isa = PBXBuildFile; fileRef = 775AAFBC1DF202B600EF6CB6 /* UBSignal+Factory.m */; };
+		775AAFC41DF2040600EF6CB6 /* UBSignal+Factory.m in Sources */ = {isa = PBXBuildFile; fileRef = 775AAFBC1DF202B600EF6CB6 /* UBSignal+Factory.m */; };
 		B643B4741C1EE50D00BE2A3B /* UBSignalTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2321B2C97E500DCAB7E /* UBSignalTests.m */; };
 		B643B4751C1EE50D00BE2A3B /* UBSignalEmitter.m in Sources */ = {isa = PBXBuildFile; fileRef = 72FED2351B2C97EB00DCAB7E /* UBSignalEmitter.m */; };
 		B643B4771C1EE50D00BE2A3B /* UberSignals.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 72FED2061B2C97C400DCAB7E /* UberSignals.framework */; };
@@ -104,6 +121,11 @@
 		72FED2321B2C97E500DCAB7E /* UBSignalTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSignalTests.m; sourceTree = "<group>"; };
 		72FED2341B2C97EB00DCAB7E /* UBSignalEmitter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBSignalEmitter.h; sourceTree = "<group>"; };
 		72FED2351B2C97EB00DCAB7E /* UBSignalEmitter.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBSignalEmitter.m; sourceTree = "<group>"; };
+		775AAFAF1DF1FFDA00EF6CB6 /* UBSignaling.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = UBSignaling.h; sourceTree = "<group>"; };
+		775AAFB41DF2009900EF6CB6 /* UBEmptySignal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UBEmptySignal.h; sourceTree = "<group>"; };
+		775AAFB51DF2009900EF6CB6 /* UBEmptySignal.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = UBEmptySignal.m; sourceTree = "<group>"; };
+		775AAFBB1DF202B600EF6CB6 /* UBSignal+Factory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "UBSignal+Factory.h"; sourceTree = "<group>"; };
+		775AAFBC1DF202B600EF6CB6 /* UBSignal+Factory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "UBSignal+Factory.m"; sourceTree = "<group>"; };
 		B643B47C1C1EE50D00BE2A3B /* UberSignals OSX Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "UberSignals OSX Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
 /* End PBXFileReference section */
 
@@ -194,6 +216,7 @@
 				72B48DF21C7E2A0200296268 /* UBBaseSignal.h */,
 				72B48DF31C7E2A0200296268 /* UBBaseSignal.m */,
 				72FED20B1B2C97C400DCAB7E /* UberSignals.h */,
+				775AAFAF1DF1FFDA00EF6CB6 /* UBSignaling.h */,
 				72FED2231B2C97D800DCAB7E /* UBSignal.h */,
 				72FED2241B2C97D800DCAB7E /* UBSignal.m */,
 				72FED2251B2C97D800DCAB7E /* UBSignal+Internal.h */,
@@ -201,6 +224,10 @@
 				72FED2271B2C97D800DCAB7E /* UBSignalObserver.h */,
 				72FED2281B2C97D800DCAB7E /* UBSignalObserver.m */,
 				72FED2291B2C97D800DCAB7E /* UBSignalObserver+Internal.h */,
+				775AAFB41DF2009900EF6CB6 /* UBEmptySignal.h */,
+				775AAFB51DF2009900EF6CB6 /* UBEmptySignal.m */,
+				775AAFBB1DF202B600EF6CB6 /* UBSignal+Factory.h */,
+				775AAFBC1DF202B600EF6CB6 /* UBSignal+Factory.m */,
 			);
 			path = UberSignals;
 			sourceTree = "<group>";
@@ -250,6 +277,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				5EBEBDBE1C162E6600E8CA02 /* UberSignals.h in Headers */,
+				775AAFBF1DF2031E00EF6CB6 /* UBSignal+Factory.h in Headers */,
+				775AAFBA1DF2011300EF6CB6 /* UBEmptySignal.h in Headers */,
+				775AAFB11DF2003C00EF6CB6 /* UBSignaling.h in Headers */,
 				5EBEBDBD1C162E6600E8CA02 /* UBSignalObserver+Internal.h in Headers */,
 				5EBEBDBA1C162E6600E8CA02 /* UBSignal+Preprocessor.h in Headers */,
 				5EBEBDBB1C162E6600E8CA02 /* UBSignalObserver.h in Headers */,
@@ -263,6 +293,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				724993401C41E1B8006653CB /* UBSignal+Internal.h in Headers */,
+				775AAFC01DF2032C00EF6CB6 /* UBSignal+Factory.h in Headers */,
+				775AAFB91DF2010F00EF6CB6 /* UBEmptySignal.h in Headers */,
+				775AAFB21DF2004200EF6CB6 /* UBSignaling.h in Headers */,
 				7249933F1C41E1B8006653CB /* UBSignal.h in Headers */,
 				724993451C41E1BC006653CB /* UberSignals.h in Headers */,
 				724993471C41E1C3006653CB /* UBSignalObserver+Internal.h in Headers */,
@@ -275,6 +308,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				724993431C41E1B9006653CB /* UBSignal+Internal.h in Headers */,
+				775AAFC11DF2033100EF6CB6 /* UBSignal+Factory.h in Headers */,
+				775AAFB81DF2010A00EF6CB6 /* UBEmptySignal.h in Headers */,
+				775AAFB31DF2004700EF6CB6 /* UBSignaling.h in Headers */,
 				724993421C41E1B9006653CB /* UBSignal.h in Headers */,
 				724993461C41E1BC006653CB /* UberSignals.h in Headers */,
 				724993481C41E1C3006653CB /* UBSignalObserver+Internal.h in Headers */,
@@ -287,6 +323,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				72FED22B1B2C97D800DCAB7E /* UBSignal.h in Headers */,
+				775AAFB01DF2003600EF6CB6 /* UBSignaling.h in Headers */,
+				775AAFBD1DF202B600EF6CB6 /* UBSignal+Factory.h in Headers */,
+				775AAFB61DF2009900EF6CB6 /* UBEmptySignal.h in Headers */,
 				72FED20C1B2C97C400DCAB7E /* UberSignals.h in Headers */,
 				72FED22D1B2C97D800DCAB7E /* UBSignal+Internal.h in Headers */,
 				72FED22E1B2C97D800DCAB7E /* UBSignal+Preprocessor.h in Headers */,
@@ -554,6 +593,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				775AAFC41DF2040600EF6CB6 /* UBSignal+Factory.m in Sources */,
 				728AB0511C7BA51600D13324 /* SwiftTests.swift in Sources */,
 				7249934E1C41E1E0006653CB /* UBSignalTests.m in Sources */,
 				7249934D1C41E1E0006653CB /* UBSignalEmitter.m in Sources */,
@@ -576,6 +616,8 @@
 			files = (
 				72FED2301B2C97D800DCAB7E /* UBSignalObserver.m in Sources */,
 				72FED22C1B2C97D800DCAB7E /* UBSignal.m in Sources */,
+				775AAFBE1DF202B600EF6CB6 /* UBSignal+Factory.m in Sources */,
+				775AAFB71DF2009900EF6CB6 /* UBEmptySignal.m in Sources */,
 				72B48DF51C7E2A0200296268 /* UBBaseSignal.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -584,6 +626,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				775AAFC21DF203F900EF6CB6 /* UBSignal+Factory.m in Sources */,
 				728AB04F1C7BA51600D13324 /* SwiftTests.swift in Sources */,
 				72FED2331B2C97E500DCAB7E /* UBSignalTests.m in Sources */,
 				72FED2361B2C97EB00DCAB7E /* UBSignalEmitter.m in Sources */,
@@ -594,6 +637,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				775AAFC31DF2040100EF6CB6 /* UBSignal+Factory.m in Sources */,
 				B643B4741C1EE50D00BE2A3B /* UBSignalTests.m in Sources */,
 				B643B4751C1EE50D00BE2A3B /* UBSignalEmitter.m in Sources */,
 			);

--- a/UberSignals/UBEmptySignal.h
+++ b/UberSignals/UBEmptySignal.h
@@ -1,0 +1,71 @@
+//
+//  UBEmptySignal.h
+//  UberSignals
+//
+//  Copyright (c) 2016 Uber Technologies, Inc.
+//
+//  Permission is hereby granted, free of charge, to any person obtaining a copy
+//  of this software and associated documentation files (the "Software"), to deal
+//  in the Software without restriction, including without limitation the rights
+//  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+//  copies of the Software, and to permit persons to whom the Software is
+//  furnished to do so, subject to the following conditions:
+//
+//  The above copyright notice and this permission notice shall be included in
+//  all copies or substantial portions of the Software.
+//
+//  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+//  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+//  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+//  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+//  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+//  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+//  THE SOFTWARE.
+
+
+#import "UBBaseSignal.h"
+#import "UBSignal+Preprocessor.h"
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A special type of signal that doesn't have any parameters.
+ */
+@protocol EmptySignal <UBSignalArgumentCount0>
+
+/**
+ Adds an observer to the Signal.
+ 
+ @param observer The observing object. The observer will be weakified and passed back to the callback as a convenience and safe-guard against retain cycles in the callback block. If the observer be deallocated, the observaiton will also be canceled.
+ @param callback A block to call whenever the Signal fires.
+ @return A UBSignalObserver that can be used to cancel the observation.
+ */
+- (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self))callback;
+
+/**
+ Returns a block that fires the signal when invoked.
+ */
+- (void (^)(void))fire;
+
+/**
+ Returns a block that fires the signal for a specific observer when invoked.
+ */
+- (void (^)(UBSignalObserver *signalObserver))fireForSignalObserver;
+
+@end
+
+/**
+ A special type of signal that doesn't have any parameters.
+ */
+@interface UBEmptySignal : UBBaseSignal <UBSignalArgumentCount0>
+
+- (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self))callback; \
+- (void (^)())fire;
+- (void (^)(UBSignalObserver *signalObserver))fireForSignalObserver;
+- (instancetype)initWithProtocol:(Protocol *)protocol NS_UNAVAILABLE;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/UberSignals/UBEmptySignal.m
+++ b/UberSignals/UBEmptySignal.m
@@ -1,8 +1,8 @@
 //
-//  UBSignal.m
+//  UBEmptySignal.m
 //  UberSignals
 //
-//  Copyright (c) 2015 Uber Technologies, Inc.
+//  Copyright (c) 2016 Uber Technologies, Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,18 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#import "UBSignal.h"
 
-#import <objc/runtime.h>
+#import "UBEmptySignal.h"
 
-#import "UBSignalObserver+Internal.h"
+NO_WARN_FOR_INCOMPLETE_IMPLEMENTATION_BEGIN
 
-CreateSignalImplementation(UBIntegerSignal, NSNumber *number);
-CreateSignalImplementation(UBFloatSignal, NSNumber *number);
-CreateSignalImplementation(UBDoubleSignal, NSNumber *number);
-CreateSignalImplementation(UBBooleanSignal, NSNumber *number);
-CreateSignalImplementation(UBStringSignal, NSString *string);
-CreateSignalImplementation(UBArraySignal, NSArray *array);
-CreateSignalImplementation(UBMutableArraySignal, NSMutableArray *mutableArray);
-CreateSignalImplementation(UBDictionarySignal, NSDictionary *dictionary);
-CreateSignalImplementation(UBMutableDictionarySignal, NSMutableDictionary *mutableDictionary);
+@implementation UBEmptySignal
 
-@implementation UBSignal : UBBaseSignal
-
-- (instancetype)initWithProtocol:(Protocol *)protocol
+- (instancetype)init
 {
-    return [super initWithProtocol:protocol];
+    return [super initWithProtocol:@protocol(UBSignalArgumentCount0)];
 }
+
+NO_WARN_FOR_INCOMPLETE_IMPLEMENTATION_END
 
 @end

--- a/UberSignals/UBSignal+Factory.h
+++ b/UberSignals/UBSignal+Factory.h
@@ -1,8 +1,8 @@
 //
-//  UBSignal.m
+//  UBSignal+Factory.h
 //  UberSignals
 //
-//  Copyright (c) 2015 Uber Technologies, Inc.
+//  Copyright (c) 2016 Uber Technologies, Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,22 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
+
 #import "UBSignal.h"
 
-#import <objc/runtime.h>
+#import <Foundation/Foundation.h>
 
-#import "UBSignalObserver+Internal.h"
+NS_ASSUME_NONNULL_BEGIN
 
-CreateSignalImplementation(UBIntegerSignal, NSNumber *number);
-CreateSignalImplementation(UBFloatSignal, NSNumber *number);
-CreateSignalImplementation(UBDoubleSignal, NSNumber *number);
-CreateSignalImplementation(UBBooleanSignal, NSNumber *number);
-CreateSignalImplementation(UBStringSignal, NSString *string);
-CreateSignalImplementation(UBArraySignal, NSArray *array);
-CreateSignalImplementation(UBMutableArraySignal, NSMutableArray *mutableArray);
-CreateSignalImplementation(UBDictionarySignal, NSDictionary *dictionary);
-CreateSignalImplementation(UBMutableDictionarySignal, NSMutableDictionary *mutableDictionary);
+CreateSignalInitializer__(Empty)
 
-@implementation UBSignal : UBBaseSignal
+@interface UBSignal (Factory)
 
-- (instancetype)initWithProtocol:(Protocol *)protocol
-{
-    return [super initWithProtocol:protocol];
-}
+/**
+ Helper factory method, constructs a Signal instance with the EmptySignal protocol.
+ */
++ (UBSignal<EmptySignal> *)emptySignal;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UberSignals/UBSignal+Factory.m
+++ b/UberSignals/UBSignal+Factory.m
@@ -1,8 +1,8 @@
 //
-//  UBSignal.m
+//  UBSignal+Factory.m
 //  UberSignals
 //
-//  Copyright (c) 2015 Uber Technologies, Inc.
+//  Copyright (c) 2016 Uber Technologies, Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,14 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#import "UBSignal.h"
 
-#import <objc/runtime.h>
+#import "UBSignal+Factory.h"
 
-#import "UBSignalObserver+Internal.h"
+@implementation UBSignal (Factory)
 
-CreateSignalImplementation(UBIntegerSignal, NSNumber *number);
-CreateSignalImplementation(UBFloatSignal, NSNumber *number);
-CreateSignalImplementation(UBDoubleSignal, NSNumber *number);
-CreateSignalImplementation(UBBooleanSignal, NSNumber *number);
-CreateSignalImplementation(UBStringSignal, NSString *string);
-CreateSignalImplementation(UBArraySignal, NSArray *array);
-CreateSignalImplementation(UBMutableArraySignal, NSMutableArray *mutableArray);
-CreateSignalImplementation(UBDictionarySignal, NSDictionary *dictionary);
-CreateSignalImplementation(UBMutableDictionarySignal, NSMutableDictionary *mutableDictionary);
-
-@implementation UBSignal : UBBaseSignal
-
-- (instancetype)initWithProtocol:(Protocol *)protocol
++ (UBSignal<EmptySignal> *)emptySignal
 {
-    return [super initWithProtocol:protocol];
+    return (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
 }
 
 @end

--- a/UberSignals/UBSignal+Preprocessor.h
+++ b/UberSignals/UBSignal+Preprocessor.h
@@ -50,7 +50,8 @@ NS_ASSUME_NONNULL_BEGIN
 #endif
 
 #define CreateSignalType_(signatureParameterCount, name, signature...) \
-    CreateSignalType__(signatureParameterCount, name, signature)
+    CreateSignalType__(signatureParameterCount, name, signature) \
+    CreateSignalInitializer__(name)
 
 #define CreateSignalType__(signatureParameterCount, name, signature...) \
     @protocol name ## Signal <UBSignalArgumentCount ## signatureParameterCount>\
@@ -58,6 +59,16 @@ NS_ASSUME_NONNULL_BEGIN
     - (void (^)(signature))fire; \
     - (void (^)(UBSignalObserver *signalObserver, signature))fireForSignalObserver; \
     @end
+
+#define CreateSignalInitializer__(name) \
+    @interface UBBaseSignal (name) \
+    + (UBSignal <name ## Signal> *)new ## name ## Signal; \
+    @end \
+    @implementation UBSignal (name) \
+    + (id)new ## name ## Signal { \
+        return [[UBSignal alloc] initWithProtocol:@protocol(name ## Signal)]; \
+    } \
+    @end \
 
 #define CreateSignalInterface_(signatureParameterCount, name, signature...) \
 CreateSignalInterface__(signatureParameterCount, name, signature)

--- a/UberSignals/UBSignal.h
+++ b/UberSignals/UBSignal.h
@@ -24,12 +24,40 @@
 
 
 #import "UBBaseSignal.h"
+#import "UBEmptySignal.h"
 #import "UBSignal+Preprocessor.h"
+#import "UBSignaling.h"
 #import "UBSignalObserver.h"
 
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
+
+/**
+ A Signal represents a type of event that Observable objects implement and fire and Observers listen to.
+ 
+ Each class that wants to implement the Observable pattern first register the types of events they fire using the CreateSignalType macro. This registers the type of data that is being fired by one of the Signals of the class to ensure type-safety. 
+ 
+ Observable classes then define properties with the naming convention on<EventName> (e.g. onNetworkData, onError, etc.) and use the appropriate type of signal type (e.g UBSignal<NetworkDataSignal>) to delcare its signals.
+ 
+ Observers register themselves to any Signals on instances they are interested in using the addObserver:callback: method of the Signal. Self is usually passed into the observer-parameter. The signal will weakify the observer pass it back to the the callback along with any parameters defined by the type of the Signal whenever the Signal fires. This way users don't have to weakify any references to self themselves and can rest assured that they're not creating retain cycles.
+ 
+ Observable classes fire the signal by retreiving the fire-block of the signal through the fire-property of the signal and calling it with the type of data registered with the Signal.
+ 
+ Signals will also detect deallocations of its observers, so it's not necessary to remove observers from Signals due to lifecycle changes.
+ */
+@interface UBSignal : UBBaseSignal <UBSignaling>
+
+/**
+ Initializes a Signal with a given protocol. An empty signal should call this initializer with the EmptySignal protocol.
+ @note A more convenient factory method is created for your signal with CreateSignalType.
+ */
+- (instancetype)initWithProtocol:(Protocol *)protocol NS_DESIGNATED_INITIALIZER;
+
+- (instancetype)init NS_UNAVAILABLE;
+
+@end
+
 
 /**
  Creates a new Signal type.
@@ -42,21 +70,21 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates the interface for a typed Signal subclass. This alternative way of creating typed signals is compatible with Swift. This should be coupled with a call to CreateSignalImplementation in your .m-file.
-
+ 
  @param className The class name of the new signal.
  @param va_args The types and names of the parameters fired by the signal. NOTE! Signal parameters all have to be objects, no primitive types allowed. If you provide primitive types the compiler won't warn you, but your firing the signal will crash the application.
  */
 #define CreateSignalInterface(className, signature...)\
-CreateSignalInterface_(PP_NARG(signature),className,signature)
+    CreateSignalInterface_(PP_NARG(signature),className,signature)
 
 /**
  Creates the implementation for a typed Signal subclass. This alternative way of creating typed signals is compatible with Swift. This should be coupled with a call to CreateSignalInterface in your header-file.
-
+ 
  @param className The class name of the new signal.
  @param va_args The types and names of the parameters fired by the signal. NOTE! Signal parameters all have to be objects, no primitive types allowed. If you provide primitive types the compiler won't warn you, but your firing the signal will crash the application.
  */
 #define CreateSignalImplementation(className, signature...)\
-CreateSignalImplementation_(PP_NARG(signature),className,signature)
+    CreateSignalImplementation_(PP_NARG(signature),className,signature)
 
 
 /** An Signal type that fires an Integer as a NSNumber */
@@ -112,102 +140,5 @@ CreateSignalInterface(UBDictionarySignal, NSDictionary *dictionary);
 
 /** An Signal type that fires a NSMutableDictionary */
 CreateSignalInterface(UBMutableDictionarySignal, NSMutableDictionary *mutableDictionary);
-
-
-/**
- A Signal represents a type of event that Observable objects implement and fire and Observers listen to.
- 
- Each class that wants to implement the Observable pattern first register the types of events they fire using the CreateSignalType macro. This registers the type of data that is being fired by one of the Signals of the class to ensure type-safety. 
- 
- Observable classes then define properties with the naming convention on<EventName> (e.g. onNetworkData, onError, etc.) and use the appropriate type of signal type (e.g UBSignal<NetworkDataSignal>) to delcare its signals.
- 
- Observers register themselves to any Signals on instances they are interested in using the addObserver:callback: method of the Signal. Self is usually passed into the observer-parameter. The signal will weakify the observer pass it back to the the callback along with any parameters defined by the type of the Signal whenever the Signal fires. This way users don't have to weakify any references to self themselves and can rest assured that they're not creating retain cycles.
- 
- Observable classes fire the signal by retreiving the fire-block of the signal through the fire-property of the signal and calling it with the type of data registered with the Signal.
- 
- Signals will also detect deallocations of its observers, so it's not necessary to remove observers from Signals due to lifecycle changes.
- */
-@protocol UBSignaling <NSObject>
-
-@property (nonatomic, assign) NSUInteger maxObservers;
-
-/**
- Notifies when an observer was added to a Signal.
- */
-@property (nonatomic, strong) UBSignalObserverChange observerAdded;
-
-/**
- Notifies when an observer was removed from a Signal.
- */
-@property (nonatomic, strong) UBSignalObserverChange observerRemoved;
-
-/**
- Removes an observer from the Signal. If the observer has registered multiple callbacks with the Signal, all of them are removed.
- 
- @param observer The observer to remove from the Signal.
- */
-- (void)removeObserver:(NSObject *)observer;
-
-/**
- Removes all observers from a Signal.
-*/
-- (void)removeAllObservers;
-
-@end
-
-/**
- A special type of signal that doesn't have any parameters.
- */
-@protocol EmptySignal <UBSignalArgumentCount0>
-
-/**
- Adds an observer to the Signal.
-
- @param observer The observing object. The observer will be weakified and passed back to the callback as a convenience and safe-guard against retain cycles in the callback block. If the observer be deallocated, the observaiton will also be canceled.
- @param callback A block to call whenever the Signal fires.
- @return A UBSignalObserver that can be used to cancel the observation.
- */
-- (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self))callback;
-
-/**
- Returns a block that fires the signal when invoked.
- */
-- (void (^)(void))fire;
-
-/**
- Returns a block that fires the signal for a specific observer when invoked.
- */
-- (void (^)(UBSignalObserver *signalObserver))fireForSignalObserver;
-
-@end
-
-
-@interface UBSignal : UBBaseSignal <UBSignaling>
-
-/**
- Helper factory method, constructs a Signal instance with the EmptySignal protocol.
- */
-+ (UBSignal<EmptySignal> *)emptySignal;
-
-/**
- Initializes a Signal with a given protocol. An empty signal should call this initializer with the EmptySignal protocol.
- */
-- (instancetype)initWithProtocol:(Protocol *)protocol NS_DESIGNATED_INITIALIZER;
-
-- (instancetype)init NS_UNAVAILABLE;
-
-@end
-
-/**
- A special type of signal that doesn't have any parameters.
- */
-@interface UBEmptySignal : UBBaseSignal <UBSignalArgumentCount0>
-
-- (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self))callback; \
-- (void (^)())fire;
-- (void (^)(UBSignalObserver *signalObserver))fireForSignalObserver;
-- (instancetype)initWithProtocol:(Protocol *)protocol NS_UNAVAILABLE;
-
-@end
 
 NS_ASSUME_NONNULL_END

--- a/UberSignals/UBSignaling.h
+++ b/UberSignals/UBSignaling.h
@@ -1,8 +1,8 @@
 //
-//  UBSignal.m
+//  UBSignaling.h
 //  UberSignals
 //
-//  Copyright (c) 2015 Uber Technologies, Inc.
+//  Copyright (c) 2016 Uber Technologies, Inc.
 //
 //  Permission is hereby granted, free of charge, to any person obtaining a copy
 //  of this software and associated documentation files (the "Software"), to deal
@@ -22,27 +22,37 @@
 //  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 //  THE SOFTWARE.
 
-#import "UBSignal.h"
 
-#import <objc/runtime.h>
+#import <Foundation/Foundation.h>
 
-#import "UBSignalObserver+Internal.h"
+NS_ASSUME_NONNULL_BEGIN
 
-CreateSignalImplementation(UBIntegerSignal, NSNumber *number);
-CreateSignalImplementation(UBFloatSignal, NSNumber *number);
-CreateSignalImplementation(UBDoubleSignal, NSNumber *number);
-CreateSignalImplementation(UBBooleanSignal, NSNumber *number);
-CreateSignalImplementation(UBStringSignal, NSString *string);
-CreateSignalImplementation(UBArraySignal, NSArray *array);
-CreateSignalImplementation(UBMutableArraySignal, NSMutableArray *mutableArray);
-CreateSignalImplementation(UBDictionarySignal, NSDictionary *dictionary);
-CreateSignalImplementation(UBMutableDictionarySignal, NSMutableDictionary *mutableDictionary);
+@protocol UBSignaling <NSObject>
 
-@implementation UBSignal : UBBaseSignal
+@property (nonatomic, assign) NSUInteger maxObservers;
 
-- (instancetype)initWithProtocol:(Protocol *)protocol
-{
-    return [super initWithProtocol:protocol];
-}
+/**
+ Notifies when an observer was added to a Signal.
+ */
+@property (nonatomic, strong) UBSignalObserverChange observerAdded;
+
+/**
+ Notifies when an observer was removed from a Signal.
+ */
+@property (nonatomic, strong) UBSignalObserverChange observerRemoved;
+
+/**
+ Removes an observer from the Signal. If the observer has registered multiple callbacks with the Signal, all of them are removed.
+ 
+ @param observer The observer to remove from the Signal.
+ */
+- (void)removeObserver:(NSObject *)observer;
+
+/**
+ Removes all observers from a Signal.
+ */
+- (void)removeAllObservers;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/UberSignals/UberSignals.h
+++ b/UberSignals/UberSignals.h
@@ -31,4 +31,5 @@ FOUNDATION_EXPORT double UberSignalsVersionNumber;
 FOUNDATION_EXPORT const unsigned char UberSignalsVersionString[];
 
 #import "UBSignal.h"
+#import "UBSignal+Factory.h"
 #import "UBSignalObserver.h"

--- a/UberSignalsTests/UBSignalTests.m
+++ b/UberSignalsTests/UBSignalTests.m
@@ -25,6 +25,7 @@
 #import <XCTest/XCTest.h>
 
 #import "UBSignalEmitter.h"
+#import "UBSignal+Factory.h"
 
 @interface UBSignalTests : XCTestCase
 @end
@@ -723,6 +724,48 @@
     XCTAssert([[signal debugDescription] containsString:@"<UBSignal: "], @"Should contain string");
     XCTAssert([[signal debugDescription] containsString:@"NSArray"], @"Should contain string");
     XCTAssert([[signal debugDescription] containsString:@"<UBSignalObserver: "], @"Should contain string");
+}
+
+- (void)testSignalFactoryMethod
+{
+    UBSignal<TupleSignal> *tupleSignal = [UBSignal newTupleSignal];
+
+    __block BOOL fired = NO;
+    __block id callbackSelf;
+    __block NSString *arg1;
+    __block NSString *arg2;
+    
+    [tupleSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {
+        fired = YES;
+        callbackSelf = self;
+        arg1 = stringData;
+        arg2 = otherStringData;
+    }];
+
+    tupleSignal.fire(@"hello", @"world");
+    
+    XCTAssert(fired, @"Signal fired");
+    XCTAssertEqual(callbackSelf, self, @"Callback should contain correct self argument");
+    XCTAssertEqualObjects(arg1, @"hello");
+    XCTAssertEqualObjects(arg2, @"world");
+}
+
+- (void)testNewEmptySignalFactoryMethod
+{
+    UBSignal<EmptySignal> *signal = [UBSignal newEmptySignal];
+    
+    __block BOOL fired;
+    __block id callbackSelf;
+    
+    [signal addObserver:self callback:^(typeof(self) self) {
+        fired = YES;
+        callbackSelf = self;
+    }];
+    
+    signal.fire();
+    
+    XCTAssert(fired, @"Signal fired");
+    XCTAssertEqual(callbackSelf, self, @"Callback should contain correct self argument");
 }
 
 @end


### PR DESCRIPTION
Currently to init a new signal you need to do the following, which involves casting and is verbose:
```
self.signal = (UBSignal<CustomDataSignal> *)[[UBSignal alloc] initWithProtocol:@protocol(CustomDataSignal)];
```

This diff automatically generates a convenience initializer, so instead you can do this, no casting:
```
self.signal = [UBSignal newCustomDataSignal];
```

To accomplish this, I had to move the macros in `UBSignal.h` below the interface definition of `UBSignal`, so I broke the file down into separate files so the macros remain above the fold.