### PR TITLE
Add "queue" to UBSignal's addObserver method

### DIFF
--- a/UberSignals/UBBaseSignal.m
+++ b/UberSignals/UBBaseSignal.m
@@ -135,8 +135,12 @@ typedef void (^UBSignalFire) (id arg1, id arg2, id arg3, id arg4, id arg5);
 
 
 #pragma mark - Public interface
-
 - (UBSignalObserver *)addObserver:(id)observer callback:(UBSignalCallback)callback
+{
+    return [self addObserver:observer queue:nil callback:callback];
+}
+
+- (UBSignalObserver *)addObserver:(id)observer queue:(nullable NSOperationQueue *)queue callback:(UBSignalCallback)callback
 {
     if (observer == nil) {
         NSAssert(NO, @"Observer cannot be nil");
@@ -149,7 +153,7 @@ typedef void (^UBSignalFire) (id arg1, id arg2, id arg3, id arg4, id arg5);
     }
 
     [self _purgeDeallocedListeners];
-    UBSignalObserver *signalObserver = [[UBSignalObserver alloc] initWithSignal:self observer:observer callback:callback];
+    UBSignalObserver *signalObserver = [[UBSignalObserver alloc] initWithSignal:self observer:observer queue:queue callback:callback];
     @synchronized(_signalObservers) {
         [_signalObservers addObject:signalObserver];
         NSAssert(_signalObservers.count <= _maxObservers, @"Maximum observer count exceeded for this signal");

--- a/UberSignals/UBSignal+Preprocessor.h
+++ b/UberSignals/UBSignal+Preprocessor.h
@@ -55,6 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 #define CreateSignalType__(signatureParameterCount, name, signature...) \
     @protocol name ## Signal <UBSignalArgumentCount ## signatureParameterCount>\
     - (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self, signature))callback; \
+    - (UBSignalObserver *)addObserver:(id)observer queue:(NSOperationQueue *)queue callback:(void (^)(id self, signature))callback; \
     - (void (^)(signature))fire; \
     - (void (^)(UBSignalObserver *signalObserver, signature))fireForSignalObserver; \
     @end
@@ -65,6 +66,7 @@ CreateSignalInterface__(signatureParameterCount, name, signature)
 #define CreateSignalInterface__(signatureParameterCount, name, signature...) \
     @interface name : UBBaseSignal <UBSignalArgumentCount ## signatureParameterCount> {} \
     - (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self, signature))callback; \
+    - (UBSignalObserver *)addObserver:(id)observer queue:(NSOperationQueue *)queue callback:(void (^)(id self, signature))callback; \
     - (void (^)(signature))fire;\
     - (void (^)(UBSignalObserver *signalObserver, signature))fireForSignalObserver; \
     - (instancetype)initWithProtocol:(Protocol *)protocol NS_UNAVAILABLE; \

--- a/UberSignals/UBSignal.h
+++ b/UberSignals/UBSignal.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Creates a new Signal type.
- 
+
  @param name The name of the signal type. "Signal" will be appended to the name and used as the name for the protocol that defines the signal type.
  @param va_args The types and names of the parameters fired by the signal. NOTE! Signal parameters all have to be objects, no primitive types allowed. If you provide primitive types the compiler won't warn you, but your firing the signal will crash the application.
  */
@@ -116,15 +116,15 @@ CreateSignalInterface(UBMutableDictionarySignal, NSMutableDictionary *mutableDic
 
 /**
  A Signal represents a type of event that Observable objects implement and fire and Observers listen to.
- 
- Each class that wants to implement the Observable pattern first register the types of events they fire using the CreateSignalType macro. This registers the type of data that is being fired by one of the Signals of the class to ensure type-safety. 
- 
+
+ Each class that wants to implement the Observable pattern first register the types of events they fire using the CreateSignalType macro. This registers the type of data that is being fired by one of the Signals of the class to ensure type-safety.
+
  Observable classes then define properties with the naming convention on<EventName> (e.g. onNetworkData, onError, etc.) and use the appropriate type of signal type (e.g UBSignal<NetworkDataSignal>) to delcare its signals.
- 
+
  Observers register themselves to any Signals on instances they are interested in using the addObserver:callback: method of the Signal. Self is usually passed into the observer-parameter. The signal will weakify the observer pass it back to the the callback along with any parameters defined by the type of the Signal whenever the Signal fires. This way users don't have to weakify any references to self themselves and can rest assured that they're not creating retain cycles.
- 
+
  Observable classes fire the signal by retreiving the fire-block of the signal through the fire-property of the signal and calling it with the type of data registered with the Signal.
- 
+
  Signals will also detect deallocations of its observers, so it's not necessary to remove observers from Signals due to lifecycle changes.
  */
 @protocol UBSignaling <NSObject>
@@ -143,7 +143,7 @@ CreateSignalInterface(UBMutableDictionarySignal, NSMutableDictionary *mutableDic
 
 /**
  Removes an observer from the Signal. If the observer has registered multiple callbacks with the Signal, all of them are removed.
- 
+
  @param observer The observer to remove from the Signal.
  */
 - (void)removeObserver:(NSObject *)observer;
@@ -168,6 +168,16 @@ CreateSignalInterface(UBMutableDictionarySignal, NSMutableDictionary *mutableDic
  @return A UBSignalObserver that can be used to cancel the observation.
  */
 - (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self))callback;
+
+/**
+ Adds an observer to the Signal.
+
+ @param observer The observing object. The observer will be weakified and passed back to the callback as a convenience and safe-guard against retain cycles in the callback block. If the observer be deallocated, the observaiton will also be canceled.
+ @param queue The queue to fire the signal on.
+ @param callback A block to call whenever the Signal fires.
+ @return A UBSignalObserver that can be used to cancel the observation.
+ */
+- (UBSignalObserver *)addObserver:(id)observer queue:(nullable NSOperationQueue *)queue callback:(void (^)(id self))callback;
 
 /**
  Returns a block that fires the signal when invoked.
@@ -203,7 +213,8 @@ CreateSignalInterface(UBMutableDictionarySignal, NSMutableDictionary *mutableDic
  */
 @interface UBEmptySignal : UBBaseSignal <UBSignalArgumentCount0>
 
-- (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self))callback; \
+- (UBSignalObserver *)addObserver:(id)observer callback:(void (^)(id self))callback;
+- (UBSignalObserver *)addObserver:(id)observer queue:(nullable NSOperationQueue *)queue callback:(void (^)(id self))callback;
 - (void (^)())fire;
 - (void (^)(UBSignalObserver *signalObserver))fireForSignalObserver;
 - (instancetype)initWithProtocol:(Protocol *)protocol NS_UNAVAILABLE;

--- a/UberSignals/UBSignalObserver+Internal.h
+++ b/UberSignals/UBSignalObserver+Internal.h
@@ -43,7 +43,7 @@ typedef void (^UBSignalCallbackArgCount5) (id listener, id arg1, id arg2, id arg
 @property (nonatomic, weak, readonly) id observer;
 @property (nonatomic, readonly) UBSignalCallback callback;
 
-- (instancetype)initWithSignal:(UBBaseSignal *)signal observer:(id)observer callback:(UBSignalCallback)callback;
+- (instancetype)initWithSignal:(UBBaseSignal *)signal observer:(id)observer queue:(NSOperationQueue *)queue callback:(UBSignalCallback)callback;
 
 @end
 

--- a/UberSignals/UBSignalObserver.h
+++ b/UberSignals/UBSignalObserver.h
@@ -43,7 +43,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  Calls the observers callback block with the last data that has been fired by the signal. If no data has been fired by the Signal or the Signal doesn't fire any data, the observers block is not called and NO is returned.
- 
+
  @return YES if the observer block was called with previous data or NO if the Signal didn't have any previous data.
  */
 - (BOOL)firePreviousData;

--- a/UberSignals/UBSignalObserver.m
+++ b/UberSignals/UBSignalObserver.m
@@ -36,13 +36,14 @@
 
 #pragma mark - Initializers
 
-- (instancetype)initWithSignal:(UBBaseSignal *)signal observer:(id)observer callback:(UBSignalCallback)callback
+- (instancetype)initWithSignal:(UBBaseSignal *)signal observer:(id)observer queue:(NSOperationQueue *)queue callback:(UBSignalCallback)callback
 {
     self = [super self];
     if (self) {
         _signal = signal;
         _observer = observer;
         _callback = callback;
+        _operationQueue = queue;
     }
     return self;
 }

--- a/UberSignalsTests/UBSignalTests.m
+++ b/UberSignalsTests/UBSignalTests.m
@@ -34,17 +34,17 @@
 - (void)testFireEmptySignal
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired;
     __block id callbackSelf;
-    
+
     [emitter.onEmptySignal addObserver:self callback:^(typeof(self) self) {
         fired = YES;
         callbackSelf = self;
     }];
-    
+
     emitter.onEmptySignal.fire();
-    
+
     XCTAssert(fired, @"Signal fired");
     XCTAssertEqual(callbackSelf, self, @"Callback should contain correct self argument");
 }
@@ -52,19 +52,19 @@
 - (void)testFireSignalWithData
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired;
     __block id callbackSelf;
     __block NSNumber *callbackInteger;
-    
+
     [emitter.onIntegerSignal addObserver:self callback:^(id self, NSNumber *integer) {
         fired = YES;
         callbackSelf = self;
         callbackInteger = integer;
     }];
-    
+
     emitter.onIntegerSignal.fire(@(10));
-    
+
     XCTAssert(fired, @"Signal fired");
     XCTAssertEqual(callbackSelf, self, @"Callback should contain correct self argument");
     XCTAssertEqual(callbackInteger, @(10), @"Should fire correct number");
@@ -73,21 +73,21 @@
 - (void)testFireSignalWithTwoDataTypes
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired;
     __block id callbackSelf;
     __block NSString *callbackStringData;
     __block NSString *callbackOtherStringData;
-    
+
     [emitter.onStringSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {
         fired = YES;
         callbackSelf = self;
         callbackStringData = stringData;
         callbackOtherStringData = otherStringData;
     }];
-    
+
     emitter.onStringSignal.fire(@"First", @"Second");
-    
+
     XCTAssert(fired, @"Signal fired");
     XCTAssertEqual(callbackSelf, self, @"Callback should contain correct self argument");
     XCTAssertEqual(callbackStringData, @"First", @"Should fire correct string");
@@ -97,27 +97,27 @@
 - (void)testFireSignalWithThreeDataTypes
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired;
-    
+
     [emitter.onTripleSignal addObserver:self callback:^(id self, NSString *string1, NSString *string2, NSNumber *number1) {
         fired = YES;
         XCTAssertEqual(string1, @"string1", @"Should get correct argument");
         XCTAssertEqual(string2, @"string2", @"Should get correct argument");
         XCTAssertEqual(number1, @(1), @"Should get correct argument");
     }];
-    
+
     emitter.onTripleSignal.fire(@"string1", @"string2", @(1));
-    
+
     XCTAssert(fired, @"Signal fired");
 }
 
 - (void)testFireSignalWithFourDataType
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired;
-    
+
     [emitter.onQuardrupleSignal addObserver:self callback:^(id self, NSString *string1, NSString *string2, NSNumber *number1, NSNumber *number2) {
         fired = YES;
         XCTAssertEqual(string1, @"string1", @"Should get correct argument");
@@ -125,20 +125,20 @@
         XCTAssertEqual(number1, @(1), @"Should get correct argument");
         XCTAssertEqual(number2, @(2), @"Should get correct argument");
     }];
-    
+
     emitter.onQuardrupleSignal.fire(@"string1", @"string2", @(1), @(2));
-    
+
     XCTAssert(fired, @"Signal fired");
 }
 
 - (void)testFireSignalWithFiveDataTypes
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired = NO;
-    
+
     [emitter.onComplexSignal addObserver:self callback:^(id self, NSNumber *number1, NSNumber *number2, NSNumber *number3, NSNumber *number4, NSNumber *number5) {
-        
+
         fired = YES;
         XCTAssertEqual(number1, @(1), @"Should get correct argument");
         XCTAssertEqual(number2, @(2), @"Should get correct argument");
@@ -146,9 +146,9 @@
         XCTAssertEqual(number4, @(4), @"Should get correct argument");
         XCTAssertEqual(number5, @(5), @"Should get correct argument");
     }];
-    
+
     emitter.onComplexSignal.fire(@(1), @(2), @(3), @(4), @(5));
-    
+
     XCTAssert(fired, @"Signal fired");
 }
 
@@ -160,21 +160,21 @@
 - (void)testFireSignalWithNilData
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired = NO;
     __block id callbackSelf = nil;
     __block NSString *callbackStringData = @"test";
     __block NSString *callbackOtherStringData = @"test";
-    
+
     [emitter.onStringSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {
         fired = YES;
         callbackSelf = self;
         callbackStringData = stringData;
         callbackOtherStringData = otherStringData;
     }];
-    
+
     emitter.onStringSignal.fire(nil, nil);
-    
+
     XCTAssert(fired, @"Signal fired");
     XCTAssertEqual(callbackSelf, self, @"Callback should contain correct self argument");
     XCTAssertNil(callbackStringData, @"Should fire correct string");
@@ -184,19 +184,19 @@
 - (void)testFireSignalForSpecificObserver
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL firstSignalFired = NO;
     __block BOOL secondSignalFired = NO;
-    
+
     UBSignalObserver *firstSignalObserver = [emitter.onEmptySignal addObserver:self callback:^(typeof(self) self) {
         firstSignalFired = YES;
     }];
     [emitter.onEmptySignal addObserver:self callback:^(typeof(self) self) {
         secondSignalFired = YES;
     }];
-    
+
     emitter.onEmptySignal.fireForSignalObserver(firstSignalObserver);
-    
+
     XCTAssertTrue(firstSignalFired, @"First signal fired");
     XCTAssertFalse(secondSignalFired, @"Second signal did not fire");
 }
@@ -204,19 +204,19 @@
 - (void)testFireSignalWithDataForSpecificObserver
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL firstSignalFired = NO;
     __block BOOL secondSignalFired = NO;
-    
+
     UBSignalObserver *firstSignalObserver = [emitter.onIntegerSignal addObserver:self callback:^(id self, NSNumber *integer) {
         firstSignalFired = YES;
     }];
     [emitter.onIntegerSignal addObserver:self callback:^(id self, NSNumber *integer) {
         secondSignalFired = YES;
     }];
-    
+
     emitter.onIntegerSignal.fireForSignalObserver(firstSignalObserver, @(10));
-    
+
     XCTAssertTrue(firstSignalFired, @"First signal fired");
     XCTAssertFalse(secondSignalFired, @"Second signal did not fire");
 }
@@ -224,19 +224,19 @@
 - (void)testFireSignalWithTwoDataTypesForSpecificObserver
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL firstSignalFired = NO;
     __block BOOL secondSignalFired = NO;
-    
+
     UBSignalObserver *firstSignalObserver = [emitter.onStringSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {
         firstSignalFired = YES;
     }];
     [emitter.onStringSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {
         secondSignalFired = YES;
     }];
-    
+
     emitter.onStringSignal.fireForSignalObserver(firstSignalObserver, @"First", @"Second");
-    
+
     XCTAssertTrue(firstSignalFired, @"First signal fired");
     XCTAssertFalse(secondSignalFired, @"Second signal did not fire");
 }
@@ -244,19 +244,19 @@
 - (void)testFireSignalWithThreeDataTypesForSpecificObserver
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL firstSignalFired = NO;
     __block BOOL secondSignalFired = NO;
-    
+
     UBSignalObserver *firstSignalObserver = [emitter.onTripleSignal addObserver:self callback:^(id self, NSString *string1, NSString *string2, NSNumber *number1) {
         firstSignalFired = YES;
     }];
     [emitter.onTripleSignal addObserver:self callback:^(id self, NSString *string1, NSString *string2, NSNumber *number1) {
         secondSignalFired = YES;
     }];
-    
+
     emitter.onTripleSignal.fireForSignalObserver(firstSignalObserver, @"string1", @"string2", @(1));
-    
+
     XCTAssertTrue(firstSignalFired, @"First signal fired");
     XCTAssertFalse(secondSignalFired, @"Second signal did not fire");
 }
@@ -264,19 +264,19 @@
 - (void)testFireSignalWithFourDataTypeForSpecificObserver
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL firstSignalFired = NO;
     __block BOOL secondSignalFired = NO;
-    
+
     UBSignalObserver *firstSignalObserver = [emitter.onQuardrupleSignal addObserver:self callback:^(id self, NSString *string1, NSString *string2, NSNumber *number1, NSNumber *number2) {
         firstSignalFired = YES;
     }];
     [emitter.onQuardrupleSignal addObserver:self callback:^(id self, NSString *string1, NSString *string2, NSNumber *number1, NSNumber *number2) {
         secondSignalFired = YES;
     }];
-    
+
     emitter.onQuardrupleSignal.fireForSignalObserver(firstSignalObserver, @"string1", @"string2", @(1), @(2));
-    
+
     XCTAssertTrue(firstSignalFired, @"First signal fired");
     XCTAssertFalse(secondSignalFired, @"Second signal did not fire");
 }
@@ -284,19 +284,19 @@
 - (void)testFireSignalWithFiveDataTypesForSpecificObserver
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL firstSignalFired = NO;
     __block BOOL secondSignalFired = NO;
-    
+
     UBSignalObserver *firstSignalObserver = [emitter.onComplexSignal addObserver:self callback:^(id self, NSNumber *number1, NSNumber *number2, NSNumber *number3, NSNumber *number4, NSNumber *number5) {
         firstSignalFired = YES;
     }];
     [emitter.onComplexSignal addObserver:self callback:^(id self, NSNumber *number1, NSNumber *number2, NSNumber *number3, NSNumber *number4, NSNumber *number5) {
         secondSignalFired = YES;
     }];
-    
+
     emitter.onComplexSignal.fireForSignalObserver(firstSignalObserver, @(1), @(2), @(3), @(4), @(5));
-    
+
     XCTAssertTrue(firstSignalFired, @"First signal fired");
     XCTAssertFalse(secondSignalFired, @"Second signal did not fire");
 }
@@ -306,10 +306,10 @@
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
     NSObject *observer1 = [[NSObject alloc] init];
     NSObject *observer2 = [[NSObject alloc] init];
-    
+
     __block BOOL fired1 = NO;
     __block BOOL fired2 = NO;
-    
+
     [emitter.onStringSignal addObserver:observer1 callback:^(id observer, NSString *stringData, NSString *otherStringData) {
         fired1 = YES;
     }];
@@ -318,7 +318,7 @@
     }];
 
     [emitter.onStringSignal removeObserver:observer1];
-    
+
     emitter.onStringSignal.fire(nil, nil);
 
     XCTAssert(fired1 == NO, @"Signal should not have fired callbacks");
@@ -337,7 +337,7 @@
     [emitter.onStringSignal addObserver:observer2 callback:^(id observer, NSString *stringData, NSString *otherStringData) {
         XCTFail(@"Signal should not have fired");
     }];
-    
+
     [emitter.onStringSignal removeAllObservers];
     emitter.onStringSignal.fire(nil, nil);
 }
@@ -345,19 +345,19 @@
 - (void)testCancelASignalObserver
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired1 = NO;
     __block BOOL fired2 = NO;
-    
+
     UBSignalObserver *signalObserver = [emitter.onStringSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {
         fired1 = YES;
     }];
     [emitter.onStringSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {
         fired2 = YES;
     }];
-    
+
     [signalObserver cancel];
-    
+
     emitter.onStringSignal.fire(nil, nil);
     XCTAssert(fired1 == NO, @"Signal should not have fired callbacks");
     XCTAssert(fired2 == YES, @"Signal should have fired callbacks");
@@ -369,18 +369,18 @@
     NSObject *observer1 = [[NSObject alloc] init];
 
     __block NSUInteger fireCount = 0;
-    
+
     UBSignalObserver *observer = [emitter.onStringSignal addObserver:observer1 callback:^(id observer, NSString *stringData, NSString *otherStringData) {
         fireCount++;
     }];
 
     emitter.onStringSignal.fire(nil, nil);
-    
+
     observer.cancelsAfterNextFire = YES;
-    
+
     emitter.onStringSignal.fire(nil, nil);
     emitter.onStringSignal.fire(nil, nil);
-    
+
     XCTAssertEqual(fireCount, 2u, @"Signal fire should have been observed three times");
 }
 
@@ -389,18 +389,18 @@
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
     NSObject *observer1 = [[NSObject alloc] init];
     emitter.onStringSignal.fire(nil, nil);
-    
+
     __block NSUInteger fireCount = 0;
 
     UBSignalObserver *observer = [emitter.onStringSignal addObserver:observer1 callback:^(id observer, NSString *stringData, NSString *otherStringData) {
         fireCount++;
     }];
-    
+
     observer.cancelsAfterNextFire = YES;
     [observer firePreviousData];
-    
+
     XCTAssertEqual(fireCount, 1u, @"Signal fire should have been observed one time");
-    
+
     emitter.onStringSignal.fire(nil, nil);
     XCTAssertEqual(fireCount, 1u, @"Signal fire should have been observed one time");
 }
@@ -409,15 +409,15 @@
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
     __block NSObject *observer = [[NSObject alloc] init];
-    
+
     __block BOOL fired = NO;
-    
+
     [emitter.onStringSignal addObserver:observer callback:^(id weakifiedObject, NSString *stringData, NSString *otherStringData) {
         fired = YES;
         observer = nil;
         XCTAssertNotNil(weakifiedObject, @"The weakified object should not have been collected");
     }];
-    
+
     emitter.onStringSignal.fire(nil, nil);
     XCTAssert(fired, @"Signal should have fired callbacks");
 }
@@ -430,7 +430,7 @@
     [emitter.onStringSignal addObserver:observer callback:^(id theWeakifiedObject, NSString *stringData, NSString *otherStringData) {
          XCTFail(@"Signal should not have fired callbacks on deallocated listener");
     }];
-    
+
     observer = nil;
     emitter.onStringSignal.fire(nil, nil);
 }
@@ -438,26 +438,26 @@
 - (void)testLateFiringOfSignal
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired = NO;
     __block id callbackSelf = nil;
     __block NSString *callbackStringData;
     __block NSString *callbackOtherStringData;
-    
+
     UBSignalObserver *signalObserver = [emitter.onStringSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {}];
     BOOL didFire = [signalObserver firePreviousData];
-    
+
     emitter.onStringSignal.fire(@"First", @"Second");
-    
+
     signalObserver = [emitter.onStringSignal addObserver:self callback:^(typeof(self) self, NSString *stringData, NSString *otherStringData) {
         fired = YES;
         callbackSelf = self;
         callbackStringData = stringData;
         callbackOtherStringData = otherStringData;
     }];
-    
+
     BOOL didFire2 = [signalObserver firePreviousData];
-    
+
     XCTAssertFalse(didFire, @"firePastData should not report data being fired");
     XCTAssertTrue(didFire2, @"firePastData should report data being fired");
     XCTAssert(fired, @"Signal fired");
@@ -473,39 +473,39 @@
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
     queue.qualityOfService = NSOperationQueuePriorityLow;
-    
+
     [emitter.onStringSignal addObserver:self callback:^(id weakifiedObject, NSString *stringData, NSString *otherStringData) {
         XCTAssert(NSOperationQueue.currentQueue == NSOperationQueue.mainQueue, @"Should have been called on the correct queue");
         [fire1 fulfill];
     }];
-    
+
     [emitter.onStringSignal addObserver:self callback:^(id weakifiedObject, NSString *stringData, NSString *otherStringData) {
         XCTAssert(NSOperationQueue.currentQueue == queue, @"Should have been called on the correct queue");
         [fire2 fulfill];
     }].operationQueue = queue;
-    
+
     emitter.onStringSignal.fire(nil, nil);
-    
+
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
 - (void)testFiringSignalOnSameOperationQueue
 {
     XCTestExpectation *fire = [self expectationWithDescription:@"Fire"];
-    
+
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
     NSOperationQueue *queue = [[NSOperationQueue alloc] init];
     queue.qualityOfService = NSOperationQueuePriorityLow;
-    
+
     [emitter.onStringSignal addObserver:self callback:^(id weakifiedObject, NSString *stringData, NSString *otherStringData) {
         XCTAssert(NSOperationQueue.currentQueue == queue, @"Should have been called on the correct queue");
         [fire fulfill];
     }].operationQueue = queue;
-    
+
     [queue addOperationWithBlock:^{
         emitter.onStringSignal.fire(nil, nil);
     }];
-    
+
     [self waitForExpectationsWithTimeout:2.0 handler:nil];
 }
 
@@ -518,78 +518,78 @@
 - (void)testDelegateAddCallback
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block BOOL fired = NO;
     emitter.onEmptySignal.observerAdded = ^(UBSignalObserver *signalObserver) {
         fired = YES;
     };
-    
+
     [emitter.onEmptySignal addObserver:self callback:^(id self) {
         // this space left intentionally blank
     }];
-    
+
     XCTAssertTrue(fired, @"observerAdded callback should have fired");
 }
 
 - (void)testDelegateRemoveCallbackOnCancel
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block UBSignalObserver *observer = nil;
     __block BOOL fired = NO;
     emitter.onEmptySignal.observerRemoved = ^(UBSignalObserver *signalObserver) {
         XCTAssertEqual(signalObserver, observer, @"signalObserver should be the same object as was originally returned by addObserver:");
         fired = YES;
     };
-    
+
     observer = [emitter.onEmptySignal addObserver:self callback:^(id self) {
         // this space left intentionally blank
     }];
     [observer cancel];
-    
+
     XCTAssertTrue(fired, @"observerRemoved callback should have fired");
 }
 
 - (void)testDelegateRemoveCallbackOnExplicitRemoval
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block UBSignalObserver *observer = nil;
     __block BOOL fired = NO;
     emitter.onEmptySignal.observerRemoved = ^(UBSignalObserver *signalObserver) {
         XCTAssertEqual(signalObserver, observer, @"signalObserver should be the same object as was originally returned by addObserver:");
         fired = YES;
     };
-    
+
     observer = [emitter.onEmptySignal addObserver:self callback:^(id self) {
         // this space left intentionally blank
     }];
     [emitter.onEmptySignal removeObserver:self];
-    
+
     XCTAssertTrue(fired, @"observerRemoved callback should have fired");
 }
 
 - (void)testDelegateRemoveCallbackOnObserverNil
 {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block UBSignalObserver *observer = nil;
     __block BOOL fired = NO;
     emitter.onEmptySignal.observerRemoved = ^(UBSignalObserver *signalObserver) {
         XCTAssertEqual(signalObserver, observer, @"signalObserver should be the same object as was originally returned by addObserver:");
         fired = YES;
     };
-    
+
     NSObject *observerObject = [[NSObject alloc] init];
     observer = [emitter.onEmptySignal addObserver:observerObject callback:^(id self) {
         // this space left intentionally blank
     }];
     observerObject = nil;
-    
+
     [emitter.onEmptySignal addObserver:self callback:^(id self) {
         // this space left intentionally blank
     }];
-    
+
     XCTAssertTrue(fired, @"observerRemoved callback should have fired");
 }
 
@@ -597,10 +597,10 @@
 {
     UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
     signal.maxObservers = 2;
-    
+
     [signal addObserver:self callback:^(id self) {}];
     [signal addObserver:self callback:^(id self) {}];
-    
+
     XCTAssertThrows([signal addObserver:self callback:^(id self) {}], @"Should have complained about max observers");
 }
 
@@ -609,7 +609,7 @@
     UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
     [signal addObserver:self callback:^(id self) {}];
     [signal addObserver:self callback:^(id self) {}];
-    
+
     XCTAssertNoThrow(signal.maxObservers = 2, @"Shouldn't have complained about max observers");
     XCTAssertThrows(signal.maxObservers = 1, @"Should have complained about max observers");
 }
@@ -618,20 +618,20 @@
 {
     UBSignal<EmptySignal> *signal = (UBSignal<EmptySignal> *)[[UBSignal alloc] initWithProtocol:@protocol(EmptySignal)];
     signal.maxObservers = 2;
-    
+
     [signal addObserver:self callback:^(id self) {}];
     [signal addObserver:self callback:^(id self) {}];
-    
+
     XCTAssertThrows([signal addObserver:self callback:^(id self) {}], @"Should have complained about max observers");
 }
 
 - (void)testRemovingListenerWhileInObserverCallback {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block NSUInteger fireCount = 0;
     __block UBSignalObserver *observer = nil;
     __block UBSignalObserver *observer2 = nil;
-    
+
     observer = [emitter.onEmptySignal addObserver:self callback:^(typeof(self) self) {
         fireCount++;
         [observer cancel];
@@ -640,15 +640,15 @@
         fireCount++;
         [observer cancel];
     }];
-    
+
     emitter.onEmptySignal.fire();
-    
+
     XCTAssertEqual(fireCount, 2u, @"Signal fired");
 }
 
 - (void)testAddListenerWhileInObserverCallback {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block NSUInteger fireCount = 0;
 
     [emitter.onEmptySignal addObserver:self callback:^(typeof(self) self) {
@@ -657,22 +657,22 @@
             fireCount++;
         }];
     }];
-    
+
     emitter.onEmptySignal.fire();
     emitter.onEmptySignal.fire();
-    
+
     XCTAssertEqual(fireCount, 3u, @"Signal fired");
 }
 
 - (void)testFiringShouldNotRetainObserver {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block NSUInteger fireCount = 0;
-    
-    
+
+
     NSObject *observer = [[NSObject alloc] init];
     __weak NSObject *weakObserver = observer;
-    
+
     @autoreleasepool {
         [emitter.onEmptySignal addObserver:observer callback:^(typeof(self) self) {
             fireCount++;
@@ -680,30 +680,30 @@
         emitter.onEmptySignal.fire();
         emitter.onEmptySignal.fire();
     }
-    
+
     observer = nil;
-    
+
     XCTAssertEqual(fireCount, 2u, @"Signal fired");
     XCTAssertNil(weakObserver, @"Should have deallocated observer");
 }
 
 - (void)testRemovingObserverWhileFiringShouldNotRetainObserver {
     UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
-    
+
     __block NSUInteger fireCount = 0;
-    
+
     NSObject *observer = [[NSObject alloc] init];
     __weak NSObject *weakObserver = observer;
-    
+
     @autoreleasepool {
         [emitter.onEmptySignal addObserver:observer callback:^(typeof(self) self) {
             fireCount++;
             [emitter.onEmptySignal removeObserver:observer];
         }];
-        
+
         emitter.onEmptySignal.fire();
         emitter.onEmptySignal.fire();
-        
+
         observer = nil;
     }
     XCTAssertEqual(fireCount, 1u, @"Signal fired");
@@ -723,6 +723,18 @@
     XCTAssert([[signal debugDescription] containsString:@"<UBSignal: "], @"Should contain string");
     XCTAssert([[signal debugDescription] containsString:@"NSArray"], @"Should contain string");
     XCTAssert([[signal debugDescription] containsString:@"<UBSignalObserver: "], @"Should contain string");
+}
+
+- (void)testUsesQueueFromParameterToAddObserver
+{
+    UBSignalEmitter *emitter = [[UBSignalEmitter alloc] init];
+
+    NSOperationQueue *testQueue = [[NSOperationQueue alloc] init];
+    UBSignalObserver *signalObserver = [emitter.onEmptySignal addObserver:self queue:testQueue callback:^(id  _Nonnull self) {
+        //noOp
+    }];
+
+    XCTAssertEqualObjects(signalObserver.operationQueue, testQueue);
 }
 
 @end


### PR DESCRIPTION
Having no way to pass in a queue at the point of observer creation opens up an opportunity for race conditions, especially since this interface specifically deals with concurrency