### PR TITLE
Mark new as unavailable interface

### DIFF
--- a/UberSignals/UBSignal.h
+++ b/UberSignals/UBSignal.h
@@ -206,6 +206,8 @@ CreateSignalInterface(UBMutableDictionarySignal, NSMutableDictionary *mutableDic
 
 - (instancetype)init NS_UNAVAILABLE;
 
++ (instancetype)new NS_UNAVAILABLE;
+
 @end
 
 /**


### PR DESCRIPTION
- Add `+ (instancetype)new NS_UNAVAILABLE;` in case there is mandatory `initWithProtocol:` interface.